### PR TITLE
More developer docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
@@ -2,13 +2,39 @@
 
 
 
-# New architecture TODOs
+# Contributor (creator of pull-request) checklist
 
-- [ ] Add your architecture to the experimental folder
+- [ ] Add your architecture to the experimental/stable folder. See the
+  [docs/src/dev-docs/architecture-life-cycle.rst](Architecture life cycle) document for
+  requirements.
   `src/metatrain/experimental/<architecture_name>`
 - [ ] Add default hyperparameter file to
-  `src/metatrain/cli/conf/architecture/experimental.<architecture_name>.yaml`
+  `src/metatrain/experimental/<architecture_name>/default-hypers.yml`
 - [ ] Add a `.yml` file into github workflows `.github/workflow/<architecture_name>.yml`
 - [ ] Architecture dependencies entry in the `optional-dependencies` section in the
   `pyproject.toml`
 - [ ] Tests: torch-scriptability, basic functionality (invariance, fitting, prediction)
+- [ ] Add maintainers as codeowners in [CODEOWNERS](CODEOWNERS)
+
+# Reviewer checklist
+
+## New experimental architectures
+
+- [ ] Capability to fit at least a single quantity and predict it, verified through CI
+   tests.
+- [ ] Compatibility with JIT compilation using `TorchScript
+   <https://pytorch.org/docs/stable/jit.html>`_.
+- [ ] Provision of reasonable default hyperparameters.
+- [ ] A contact person designated as the maintainer.
+- [ ] All external dependencies must be pip-installable. While not required to be on
+   PyPI, a public git repository or another public URL with a repository is acceptable.
+
+
+## New stable architectures
+- [ ] Provision of regression prediction tests with a small (not exported) checkpoint
+  file.
+- [ ] Comprehensive architecture documentation
+- [ ] If an architecture has external dependencies, all must be publicly available on
+  PyPI.
+- [ ] Adherence to the standard output infrastructure of `metatensor-models`, including
+   logging and model save locations.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
@@ -36,5 +36,5 @@
 - [ ] Comprehensive architecture documentation
 - [ ] If an architecture has external dependencies, all must be publicly available on
   PyPI.
-- [ ] Adherence to the standard output infrastructure of `metatensor-models`, including
+- [ ] Adherence to the standard output infrastructure of `metatrain`, including
    logging and model save locations.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
@@ -25,7 +25,7 @@
 - [ ] Compatibility with JIT compilation using `TorchScript
    <https://pytorch.org/docs/stable/jit.html>`_.
 - [ ] Provision of reasonable default hyperparameters.
-- [ ] A contact person designated as the maintainer.
+- [ ] A contact person designated as the maintainer, mentioned in `__maintainers__` and the `CODEOWNERS` file
 - [ ] All external dependencies must be pip-installable. While not required to be on
    PyPI, a public git repository or another public URL with a repository is acceptable.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 Please go the the `Preview` tab and select the appropriate PR template:
 
-* [Default template](?expand=1&template=pull_request_template.md)
-* [Adding a new architecture](?expand=1&template=pull_request_new-architecture.md)
+- [Default template](?expand=1&template=pull_request_template.md)
+- [Adding a new architecture](?expand=1&template=pull_request_new-architecture.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate PR template:
+
+* [Default template](?expand=1&template=pull_request_template.md)
+* [Adding a new architecture](?expand=1&template=pull_request_new-architecture.md)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,8 +54,9 @@ Then this package itself
 
 .. code-block:: bash
 
-  git clone https://github.com/lab-cosmo/metatensor-models cd metatensor-models pip
-  install -e .
+  git clone https://github.com/lab-cosmo/metatensor-models 
+  cd metatensor-models 
+  pip install -e .
 
 This install the package in development mode, making it importable globally and allowing
 you to edit the code and directly use the updated version. To see a list of all
@@ -96,7 +97,7 @@ If you want to test a specific archicture you can also do it. For example
       tox -e soap-bpnn-tests
 
 Will run the unit and regression tests for the :ref:`SOAP-BPNN <architecture-soap-bpnn>`
-model. Note that architecture tests are not run by default if yiu just type ``tox``.
+model. Note that architecture tests are not run by default if you just type ``tox``.
 
 .. _unittest: https://docs.python.org/3/library/unittest.html
 .. _tox: https://tox.readthedocs.io/en/latest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,131 @@
+.. _contributing:
+
+Contributing
+============
+🎉 First off, thanks for taking the time to contribute to metatensor-models! 🎉
+
+If you want to contribute but feel a bit lost, do not hesitate to contact us and ask
+your questions! We will happily mentor you through your first contributions.
+
+Area of contributions
+---------------------
+The first and best way to contribute to metatensor-models is to use it and advertise it
+to other potential users. Other than that, you can help with:
+
+- documentation: correcting typos, making various documentation clearer;
+- bug fixes and improvements to existing code;
+- adding new architectures
+- and many more ...
+
+All these contributions are very welcome. We accept contributions via Github `pull
+request <https://github.com/metatensor-models/pulls>`_. If you want to work on the code
+and pick something easy to get started, have a look at the `good first issues
+<https://github.com/lab-cosmo/metatensor-models/labels/Good%20first%20issue>`_.
+
+
+Bug reports and feature requests
+--------------------------------
+Bug and feature requests should be reported as `Github issues
+<https://github.com/metatensor-models/issues>`_. For bugs, you should provide
+information so that we can reproduce it: what did you try? What did you expect? What
+happened instead? Please provide any useful code snippet or input file with your bug
+report.
+
+If you want to add a new feature to metatensor-models, please create an `issue
+<https://github.com/lab-cosmo/metatensor-models/issues/new>`_ so that we can discuss it,
+and you have more chances to see your changes incorporated.
+
+
+Contribution tutorial
+---------------------
+In this small tutorial, you should replace `<angle brackets>` as needed. If anything is
+unclear, please ask for clarifications! There are no dumb questions.
+
+Getting started
+---------------
+To help with developing start by installing the development dependencies:
+
+.. code-block:: bash
+
+  pip install tox
+
+
+Then this package itself
+
+.. code-block:: bash
+
+  git clone https://github.com/lab-cosmo/metatensor-models cd metatensor-models pip
+  install -e .
+
+This install the package in development mode, making it importable globally and allowing
+you to edit the code and directly use the updated version. To see a list of all
+supported tox environments please use
+
+.. code-block:: bash
+
+  tox list
+
+Running the tests
+-----------------
+The testsuite is implemented using Python's `unittest`_ framework and should be set-up
+and run in an isolated virtual environment with `tox`_. All tests can be run with
+
+.. code-block:: bash
+
+  tox                  # all tests
+
+If you wish to test only specific functionalities, for example:
+
+.. code-block:: bash
+
+  tox -e lint          # code style
+  tox -e tests         # unit tests of the main library
+  tox -e examples      # test the examples
+
+
+You can also use ``tox -e format`` to use tox to do actual formatting instead of just
+testing it. Also, you may want to setup your editor to automatically apply the `black
+<https://black.readthedocs.io/en/stable/>`_ code formatter when saving your files, there
+are plugins to do this with `all major editors
+<https://black.readthedocs.io/en/stable/editor_integration.html>`_.
+
+If you want to test a specific archicture you can also do it. For example
+
+.. code-block:: bash
+
+      tox -e soap-bpnn-tests
+
+Will run the unit and regression tests for the :ref:`SOAP-BPNN <architecture-soap-bpnn>`
+model. Note that architecture tests are not run by default if yiu just type ``tox``.
+
+.. _unittest: https://docs.python.org/3/library/unittest.html
+.. _tox: https://tox.readthedocs.io/en/latest
+
+Contributing to the documentation
+---------------------------------
+The documentation is written in reStructuredText (rst) and uses `sphinx`_ documentation
+generator. In order to modify the documentation, first create a local version on your
+machine as described above. Then, build the documentation with
+
+.. code-block:: bash
+
+    tox -e docs
+
+You can then visualize the local documentation with your favorite browser using the
+following command (or open the :file:`docs/build/html/index.html` file manually).
+
+.. code-block:: bash
+
+    # on linux, depending on what package you have installed:
+    xdg-open docs/build/html/index.html
+    firefox docs/build/html/index.html
+
+    # on macOS:
+    open docs/build/html/index.html
+
+.. _`sphinx` : https://www.sphinx-doc.org
+
+Contributing new architectures
+------------------------------
+If you want to contribute a new model pleas read the pages on
+:ref:`architecture-life-cycle` and :ref:`adding-new-architecture`.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,14 +2,14 @@
 
 Contributing
 ============
-🎉 First off, thanks for taking the time to contribute to metatensor-models! 🎉
+🎉 First off, thanks for taking the time to contribute to metatrain! 🎉
 
 If you want to contribute but feel a bit lost, do not hesitate to contact us and ask
 your questions! We will happily mentor you through your first contributions.
 
 Area of contributions
 ---------------------
-The first and best way to contribute to metatensor-models is to use it and advertise it
+The first and best way to contribute to metatrain is to use it and advertise it
 to other potential users. Other than that, you can help with:
 
 - documentation: correcting typos, making various documentation clearer;
@@ -18,21 +18,21 @@ to other potential users. Other than that, you can help with:
 - and many more ...
 
 All these contributions are very welcome. We accept contributions via Github `pull
-request <https://github.com/metatensor-models/pulls>`_. If you want to work on the code
+request <https://github.com/metatrain/pulls>`_. If you want to work on the code
 and pick something easy to get started, have a look at the `good first issues
-<https://github.com/lab-cosmo/metatensor-models/labels/Good%20first%20issue>`_.
+<https://github.com/lab-cosmo/metatrain/labels/Good%20first%20issue>`_.
 
 
 Bug reports and feature requests
 --------------------------------
 Bug and feature requests should be reported as `Github issues
-<https://github.com/metatensor-models/issues>`_. For bugs, you should provide
+<https://github.com/metatrain/issues>`_. For bugs, you should provide
 information so that we can reproduce it: what did you try? What did you expect? What
 happened instead? Please provide any useful code snippet or input file with your bug
 report.
 
-If you want to add a new feature to metatensor-models, please create an `issue
-<https://github.com/lab-cosmo/metatensor-models/issues/new>`_ so that we can discuss it,
+If you want to add a new feature to metatrain, please create an `issue
+<https://github.com/lab-cosmo/metatrain/issues/new>`_ so that we can discuss it,
 and you have more chances to see your changes incorporated.
 
 
@@ -54,8 +54,8 @@ Then this package itself
 
 .. code-block:: bash
 
-  git clone https://github.com/lab-cosmo/metatensor-models 
-  cd metatensor-models 
+  git clone https://github.com/lab-cosmo/metatrain 
+  cd metatrain 
   pip install -e .
 
 This install the package in development mode, making it importable globally and allowing

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,8 +12,9 @@ prune .tox
 
 exclude .codecov.yml
 exclude .gitignore
-exclude tox.ini
 exclude .readthedocs.yml
 exclude CODEOWNERS
+exclude CONTRIBUTING.rst
+exclude tox.ini
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib

--- a/docs/src/architectures/gap.rst
+++ b/docs/src/architectures/gap.rst
@@ -12,7 +12,7 @@ implemented in `rascaline <RASCALINE_>`_.
 .. _GAP:  https://doi.org/10.1002/qua.24927
 .. _RASCALINE: https://github.com/Luthaf/rascaline
 
-The GAP model in metatensor-models can only train on CPU, but evaluation
+The GAP model in metatrain can only train on CPU, but evaluation
 is also supported on GPU.
 
 

--- a/docs/src/architectures/pet.rst
+++ b/docs/src/architectures/pet.rst
@@ -5,7 +5,7 @@ PET
 
 .. warning::
 
-    The metatensor-models interface to PET is **experimental**. You should
+    The metatrain interface to PET is **experimental**. You should
     not use it for anything important. Alternatively, for a moment, consider
     using (nonexperimental) native scripts available `here
     <https://spozdn.github.io/pet/train_model.html>`_.

--- a/docs/src/dev-docs/architecture-life-cycle.rst
+++ b/docs/src/dev-docs/architecture-life-cycle.rst
@@ -1,3 +1,5 @@
+.. _architecture-life-cycle:
+
 Life Cycle of an Architecture
 =============================
 

--- a/docs/src/dev-docs/architecture-life-cycle.rst
+++ b/docs/src/dev-docs/architecture-life-cycle.rst
@@ -16,7 +16,7 @@ removal if maintenance is no longer feasible.
     architecture's internal functionality or any issues that may arise therein.
 
 Experimental Architectures
----------------------------
+--------------------------
 
 New architectures added to the library will initially be classified as experimental.
 These architectures are stored in the ``experimental`` subdirectory within the

--- a/docs/src/dev-docs/getting-started.rst
+++ b/docs/src/dev-docs/getting-started.rst
@@ -1,0 +1,3 @@
+.. _label_dev-getting-started:
+
+.. include:: ../../../CONTRIBUTING.rst

--- a/docs/src/dev-docs/index.rst
+++ b/docs/src/dev-docs/index.rst
@@ -9,6 +9,7 @@ module.
 .. toctree::
    :maxdepth: 1
 
+   getting-started
    architecture-life-cycle
    new-architecture
    cli/index

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -48,7 +48,7 @@ In order to follow this, a new architectures has two define two classes
 
 .. note::
 
-    ``metatensor-models`` does not know the types and numbers of targets/datasets that
+    ``metatrain`` does not know the types and numbers of targets/datasets that
     an architecture can handle. As a result, it cannot generate useful error messages
     when a user attempts to train an architecture with unsupported target and dataset
     combinations. Therefore, it is the responsibility of the architecture developer to

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -46,6 +46,16 @@ In order to follow this, a new architectures has two define two classes
   evaluated and exported. This class must implement the interface documented below in
   :py:class:`TrainerInterface`.
 
+.. note::
+
+    ``metatensor-models`` does not know the types and numbers of targets/datasets that
+    an architecture can handle. As a result, it cannot generate useful error messages
+    when a user attempts to train an architecture with unsupported target and dataset
+    combinations. Therefore, it is the responsibility of the architecture developer to
+    verify if the model and the trainer support the provided train_datasets and
+    validation_datasets passed to the Trainer, as well as the dataset_info passed to the
+    model.
+
 The ``ModelInterface`` is the main model class and must implement a
 ``save_checkpoint()``, ``load_checkpoint()``  as well as a ``restart()`` and
 ``export()`` method.
@@ -57,7 +67,7 @@ The ``ModelInterface`` is the main model class and must implement a
         __supported_devices__ = ["cuda", "cpu"]
         __supported_dtypes__ = [torch.float64, torch.float32]
 
-        def __init__(self, model_hypers, dataset_info: DatasetInfo):
+        def __init__(self, model_hypers: Dict, dataset_info: DatasetInfo):
             self.hypers = model_hypers
             self.dataset_info = dataset_info
 
@@ -135,10 +145,10 @@ these two constants the ``__init__.py`` must contain constants for the original
 
 
 :param __model__: Mapping of the custom ``ModelInterface`` to a general one to be loaded
-    by metatrain
+    by ``metatrain``.
 :param __trainer__: Same as ``__MODEL_CLASS__`` but the Trainer class.
 :param __authors__: Tuple denoting the original authors with email address and Github
     handle of an architecture. These do not necessary be in charge of maintaining the
-    the architecture
+    the architecture.
 :param __maintainers__: Tuple denoting the current maintainers of the architecture. Uses
     the same style as the ``__authors__`` constant.


### PR DESCRIPTION
Fixes #92, #225

Additional information for new contributors.

I am not sure why our old PR templates were not working. According to this [stackoverflow discussion](https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github), I am now using a entry template to choose from.

Let me know if I forgot any information.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview metatensor-models end -->