### PR TITLE
Use tempory directory for sphinx .doctree folder

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,12 @@ commands =
     #bash -c "set -e && cd {toxinidir}/examples/basic_usage && bash usage.sh"
     # Disable slow training at runtime for ase example to speed up CI for now.
     #bash -c "set -e && cd {toxinidir}/examples/ase && bash train_export.sh"
-    sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
+    sphinx-build \
+        {posargs:-E} \
+        --builder html \
+        --doctree-dir docs/build/doctree \
+        --fail-on-warning \
+        docs/src docs/build/html
 
 [flake8]
 # longer lines for compatibility with other linters


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

As discussed in #213, the large `.doctree` folder should be created in a temporary directory. This is done in this PR and should further reduce the size of the repository.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--233.org.readthedocs.build/en/233/

<!-- readthedocs-preview metatrain end -->