### PR TITLE
`Systems` in tests

### DIFF
--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -27,7 +27,7 @@ def test_to(device, dtype):
     exported.to(device=device)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, System, systems_to_torch
+from metatensor.torch.atomistic import ModelEvaluationOptions, System
 
 from metatrain.experimental.alchemical_model import AlchemicalModel
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -27,7 +27,7 @@ def test_to(device, dtype):
     exported.to(device=device)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -28,10 +28,8 @@ def test_to(device, dtype):
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)

--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -1,4 +1,4 @@
-import ase
+from metatensor.torch.atomistic import System
 import pytest
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
@@ -27,8 +27,7 @@ def test_to(device, dtype):
 
     exported.to(device=device)
 
-    system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(system, dtype=torch.get_default_dtype())
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -1,7 +1,6 @@
-from metatensor.torch.atomistic import System
 import pytest
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
+from metatensor.torch.atomistic import ModelEvaluationOptions, System, systems_to_torch
 
 from metatrain.experimental.alchemical_model import AlchemicalModel
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -27,7 +26,13 @@ def test_to(device, dtype):
 
     exported.to(device=device)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -22,10 +22,8 @@ def test_prediction_subset_elements():
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -21,7 +21,7 @@ def test_prediction_subset_elements():
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -21,7 +21,7 @@ def test_prediction_subset_elements():
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -20,7 +20,13 @@ def test_prediction_subset_elements():
 
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -1,5 +1,5 @@
-import ase
-from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
+import torch
+from metatensor.torch.atomistic import ModelEvaluationOptions, System
 
 from metatrain.experimental.alchemical_model import AlchemicalModel
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -20,8 +20,7 @@ def test_prediction_subset_elements():
 
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
-    system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(system)
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(

--- a/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
@@ -1,10 +1,11 @@
 import copy
 
+import ase.io
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
 
 from metatrain.experimental.alchemical_model import AlchemicalModel
-from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict, read_systems
+from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 
 from . import DATASET_PATH, MODEL_HYPERS
@@ -20,12 +21,14 @@ def test_rotational_invariance():
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
-    system = read_systems(filename=DATASET_PATH)[0]
+    system = ase.io.read(DATASET_PATH)
     original_system = copy.deepcopy(system)
     original_system = systems_to_torch(original_system)
     original_system = get_system_with_neighbor_lists(
         original_system, model.requested_neighbor_lists()
     )
+
+    system.rotate(48, "y")
     system = systems_to_torch(system)
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
@@ -1,11 +1,10 @@
 import copy
 
-import ase.io
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
 
 from metatrain.experimental.alchemical_model import AlchemicalModel
-from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
+from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict, read_systems
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 
 from . import DATASET_PATH, MODEL_HYPERS
@@ -21,7 +20,7 @@ def test_rotational_invariance():
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
-    system = ase.io.read(DATASET_PATH)
+    system = read_systems(filename=DATASET_PATH)[0]
     original_system = copy.deepcopy(system)
     original_system = systems_to_torch(original_system)
     original_system = get_system_with_neighbor_lists(

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -2,7 +2,7 @@ import random
 
 import numpy as np
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
+from metatensor.torch.atomistic import ModelEvaluationOptions
 from omegaconf import OmegaConf
 
 from metatrain.experimental.alchemical_model import AlchemicalModel, Trainer
@@ -38,7 +38,6 @@ def test_regression_init():
 
     # Predict on the first five systems
     systems = read_systems(DATASET_PATH)[:5]
-    systems = [systems_to_torch(system) for system in systems]
     systems = [
         get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
         for system in systems

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -1,15 +1,19 @@
 import random
 
-import ase.io
 import numpy as np
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
 from omegaconf import OmegaConf
 
 from metatrain.experimental.alchemical_model import AlchemicalModel, Trainer
-from metatrain.utils.data import Dataset, DatasetInfo, TargetInfo
+from metatrain.utils.data import (
+    Dataset,
+    DatasetInfo,
+    TargetInfo,
+    read_systems,
+    read_targets,
+)
 from metatrain.utils.data.dataset import TargetInfoDict
-from metatrain.utils.data.readers import read_systems, read_targets
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
@@ -33,7 +37,7 @@ def test_regression_init():
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
     # Predict on the first five systems
-    systems = ase.io.read(DATASET_PATH, ":5")
+    systems = read_systems(DATASET_PATH)[:5]
     systems = [systems_to_torch(system) for system in systems]
     systems = [
         get_system_with_neighbor_lists(system, model.requested_neighbor_lists())

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -55,7 +55,7 @@ def test_to(device):
     exported.to(device=device, dtype=dtype)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -56,10 +56,8 @@ def test_to(device):
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -1,4 +1,3 @@
-import torch
 import pytest
 import torch
 from metatensor.torch.atomistic import (
@@ -55,7 +54,13 @@ def test_to(device):
     exported = export(model, capabilities)
     exported.to(device=device, dtype=dtype)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -1,11 +1,11 @@
-import ase
+import torch
 import pytest
 import torch
 from metatensor.torch.atomistic import (
     ModelCapabilities,
     ModelEvaluationOptions,
     ModelOutput,
-    systems_to_torch,
+    System,
 )
 from pet.hypers import Hypers
 from pet.pet import PET
@@ -55,8 +55,7 @@ def test_to(device):
     exported = export(model, capabilities)
     exported.to(device=device, dtype=dtype)
 
-    system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(system, dtype=torch.get_default_dtype())
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -55,7 +55,7 @@ def test_to(device):
     exported.to(device=device, dtype=dtype)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -7,7 +7,7 @@ from metatensor.torch.atomistic import (
     ModelEvaluationOptions,
     ModelMetadata,
     ModelOutput,
-    systems_to_torch,
+    System,
 )
 from pet.hypers import Hypers
 from pet.pet import PET
@@ -34,8 +34,7 @@ def test_prediction():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    structure = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(structure)
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(
@@ -80,8 +79,7 @@ def test_per_atom_predictions_functionality():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    structure = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(structure)
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(
@@ -127,8 +125,7 @@ def test_selected_atoms_functionality():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    structure = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(structure)
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -1,4 +1,3 @@
-import ase
 import torch
 from metatensor.torch import Labels
 from metatensor.torch.atomistic import (
@@ -35,7 +34,7 @@ def test_prediction():
     model.set_trained_model(raw_pet)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -86,7 +85,7 @@ def test_per_atom_predictions_functionality():
     model.set_trained_model(raw_pet)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -138,7 +137,7 @@ def test_selected_atoms_functionality():
     model.set_trained_model(raw_pet)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -35,10 +35,8 @@ def test_prediction():
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
@@ -86,10 +84,8 @@ def test_per_atom_predictions_functionality():
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
@@ -138,10 +134,8 @@ def test_selected_atoms_functionality():
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -34,7 +34,7 @@ def test_prediction():
     model.set_trained_model(raw_pet)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -85,7 +85,7 @@ def test_per_atom_predictions_functionality():
     model.set_trained_model(raw_pet)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -137,7 +137,7 @@ def test_selected_atoms_functionality():
     model.set_trained_model(raw_pet)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -34,7 +34,13 @@ def test_prediction():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(
@@ -79,7 +85,13 @@ def test_per_atom_predictions_functionality():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(
@@ -125,7 +137,13 @@ def test_selected_atoms_functionality():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     evaluation_options = ModelEvaluationOptions(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -27,7 +27,7 @@ def test_to(device, dtype):
     exported.to(device=device)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -28,10 +28,8 @@ def test_to(device, dtype):
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -1,7 +1,6 @@
-import ase
 import pytest
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, systems_to_torch
+from metatensor.torch.atomistic import ModelEvaluationOptions, System
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -28,7 +27,7 @@ def test_to(device, dtype):
     exported.to(device=device)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -27,8 +27,7 @@ def test_to(device, dtype):
 
     exported.to(device=device)
 
-    system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(system, dtype=torch.get_default_dtype())
+    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -27,7 +27,13 @@ def test_to(device, dtype):
 
     exported.to(device=device)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     system = get_system_with_neighbor_lists(system, exported.requested_neighbor_lists())
     system = system.to(device=device, dtype=dtype)
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -22,10 +22,8 @@ def test_prediction_subset_elements():
 
     system = System(
         types=torch.tensor([6, 6]),
-        positions=torch.tensor(
-            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
-        ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+        cell=torch.zeros(3, 3),
     )
     model(
         [system],
@@ -52,9 +50,8 @@ def test_prediction_subset_atoms():
         types=torch.tensor([7, 8, 8]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]],
-            dtype=torch.get_default_dtype(),
         ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        cell=torch.zeros(3, 3),
     )
 
     energy_monomer = model(
@@ -73,9 +70,8 @@ def test_prediction_subset_atoms():
                 [0.0, 51.0, 0.0],
                 [0.0, 42.0, 0.0],
             ],
-            dtype=torch.get_default_dtype(),
         ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        cell=torch.zeros(3, 3),
     )
 
     selection_labels = metatensor.torch.Labels(
@@ -117,9 +113,8 @@ def test_output_last_layer_features():
         types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
-            dtype=torch.get_default_dtype(),
         ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        cell=torch.zeros(3, 3),
     )
 
     # last-layer features per atom:
@@ -189,9 +184,8 @@ def test_output_per_atom():
         types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
-            dtype=torch.get_default_dtype(),
         ),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+        cell=torch.zeros(3, 3),
     )
 
     outputs = model(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -1,4 +1,3 @@
-import ase
 import metatensor.torch
 import torch
 from metatensor.torch.atomistic import ModelOutput, System, systems_to_torch
@@ -22,7 +21,7 @@ def test_prediction_subset_elements():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        atomic_types=[6, 6],
+        types=[6, 6],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -50,7 +49,7 @@ def test_prediction_subset_atoms():
     # predicting on a system with two monomers at a large distance
 
     system_monomer = System(
-        atomic_types=[7, 8, 8],
+        types=[7, 8, 8],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]],
             dtype=torch.get_default_dtype(),
@@ -64,7 +63,7 @@ def test_prediction_subset_atoms():
     )
 
     system_far_away_dimer = System(
-        atomic_types=[7, 7, 8, 8, 8, 8],
+        types=[7, 7, 8, 8, 8, 8],
         positions=torch.tensor(
             [
                 [0.0, 0.0, 0.0],
@@ -114,7 +113,7 @@ def test_output_last_layer_features():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        atomic_types=[6, 1, 8, 7],
+        types=[6, 1, 8, 7],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
             dtype=torch.get_default_dtype(),
@@ -186,7 +185,7 @@ def test_output_per_atom():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        atomic_types=[6, 1, 8, 7],
+        types=[6, 1, 8, 7],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
             dtype=torch.get_default_dtype(),

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -21,7 +21,7 @@ def test_prediction_subset_elements():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        types=[6, 6],
+        types=torch.tensor([6, 6]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
         ),
@@ -49,7 +49,7 @@ def test_prediction_subset_atoms():
     # predicting on a system with two monomers at a large distance
 
     system_monomer = System(
-        types=[7, 8, 8],
+        types=torch.tensor([7, 8, 8]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]],
             dtype=torch.get_default_dtype(),
@@ -63,7 +63,7 @@ def test_prediction_subset_atoms():
     )
 
     system_far_away_dimer = System(
-        types=[7, 7, 8, 8, 8, 8],
+        types=torch.tensor([7, 7, 8, 8, 8, 8]),
         positions=torch.tensor(
             [
                 [0.0, 0.0, 0.0],
@@ -113,7 +113,7 @@ def test_output_last_layer_features():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        types=[6, 1, 8, 7],
+        types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
             dtype=torch.get_default_dtype(),
@@ -185,7 +185,7 @@ def test_output_per_atom():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     system = System(
-        types=[6, 1, 8, 7],
+        types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
             dtype=torch.get_default_dtype(),

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -1,7 +1,7 @@
 import ase
 import metatensor.torch
 import torch
-from metatensor.torch.atomistic import ModelOutput, systems_to_torch, System
+from metatensor.torch.atomistic import ModelOutput, System, systems_to_torch
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -21,7 +21,13 @@ def test_prediction_subset_elements():
 
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
-    system = System(atomic_types=[6, 6], positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()), cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()))
+    system = System(
+        atomic_types=[6, 6],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.get_default_dtype()
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
+    )
     model(
         [system],
         {"energy": model.outputs["energy"]},
@@ -45,8 +51,11 @@ def test_prediction_subset_atoms():
 
     system_monomer = System(
         atomic_types=[7, 8, 8],
-        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], dtype=torch.get_default_dtype()),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype())
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]],
+            dtype=torch.get_default_dtype(),
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
     )
 
     energy_monomer = model(
@@ -56,15 +65,17 @@ def test_prediction_subset_atoms():
 
     system_far_away_dimer = System(
         atomic_types=[7, 7, 8, 8, 8, 8],
-        positions=torch.tensor([
-            [0.0, 0.0, 0.0],
-            [0.0, 50.0, 0.0],
-            [0.0, 0.0, 1.0],
-            [0.0, 0.0, 2.0],
-            [0.0, 51.0, 0.0],
-            [0.0, 42.0, 0.0],
-        ]),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype())
+        positions=torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 50.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 2.0],
+                [0.0, 51.0, 0.0],
+                [0.0, 42.0, 0.0],
+            ]
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
     )
 
     selection_labels = metatensor.torch.Labels(
@@ -104,8 +115,11 @@ def test_output_last_layer_features():
 
     system = System(
         atomic_types=[6, 1, 8, 7],
-        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]], dtype=torch.get_default_dtype()),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype())
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+            dtype=torch.get_default_dtype(),
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
     )
 
     # last-layer features per atom:
@@ -173,8 +187,11 @@ def test_output_per_atom():
 
     system = System(
         atomic_types=[6, 1, 8, 7],
-        positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]], dtype=torch.get_default_dtype()),
-        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype())
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+            dtype=torch.get_default_dtype(),
+        ),
+        cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
     )
 
     outputs = model(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -1,6 +1,6 @@
 import metatensor.torch
 import torch
-from metatensor.torch.atomistic import ModelOutput, System, systems_to_torch
+from metatensor.torch.atomistic import ModelOutput, System
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -72,7 +72,8 @@ def test_prediction_subset_atoms():
                 [0.0, 0.0, 2.0],
                 [0.0, 51.0, 0.0],
                 [0.0, 42.0, 0.0],
-            ]
+            ],
+            dtype=torch.get_default_dtype(),
         ),
         cell=torch.zeros(3, 3, dtype=torch.get_default_dtype()),
     )
@@ -83,12 +84,12 @@ def test_prediction_subset_atoms():
     )
 
     energy_dimer = model(
-        [systems_to_torch(system_far_away_dimer)],
+        [system_far_away_dimer],
         {"energy": ModelOutput(per_atom=False)},
     )
 
     energy_monomer_in_dimer = model(
-        [systems_to_torch(system_far_away_dimer)],
+        [system_far_away_dimer],
         {"energy": ModelOutput(per_atom=False)},
         selected_atoms=selection_labels,
     )
@@ -156,7 +157,7 @@ def test_output_last_layer_features():
         per_atom=False,
     )
     outputs = model(
-        [systems_to_torch(system, dtype=torch.get_default_dtype())],
+        [system],
         {
             "energy": model.outputs["energy"],
             "mtm::aux::last_layer_features": ll_output_options,

--- a/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
@@ -1,9 +1,8 @@
 import random
 
-import ase.io
 import numpy as np
 import torch
-from metatensor.torch.atomistic import ModelOutput, systems_to_torch
+from metatensor.torch.atomistic import ModelOutput
 from omegaconf import OmegaConf
 
 from metatrain.experimental.soap_bpnn import SoapBpnn, Trainer
@@ -31,10 +30,10 @@ def test_regression_init():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
     # Predict on the first five systems
-    systems = ase.io.read(DATASET_PATH, ":5")
+    systems = read_systems(DATASET_PATH)[:5]
 
     output = model(
-        [systems_to_torch(system) for system in systems],
+        systems,
         {"mtm::U0": ModelOutput(quantity="energy", unit="", per_atom=False)},
     )
 
@@ -55,7 +54,7 @@ def test_regression_train():
     """Perform a regression test on the model when
     trained for 2 epoch on a small dataset"""
 
-    systems = read_systems(DATASET_PATH)
+    systems = read_systems(DATASET_PATH)[:5]
 
     conf = {
         "mtm::U0": {
@@ -86,7 +85,7 @@ def test_regression_train():
 
     # Predict on the first five systems
     output = model(
-        systems[:5],
+        systems,
         {"mtm::U0": ModelOutput(quantity="energy", unit="", per_atom=False)},
     )
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
@@ -54,7 +54,7 @@ def test_regression_train():
     """Perform a regression test on the model when
     trained for 2 epoch on a small dataset"""
 
-    systems = read_systems(DATASET_PATH)[:5]
+    systems = read_systems(DATASET_PATH)
 
     conf = {
         "mtm::U0": {
@@ -85,7 +85,7 @@ def test_regression_train():
 
     # Predict on the first five systems
     output = model(
-        systems,
+        systems[:5],
         {"mtm::U0": ModelOutput(quantity="energy", unit="", per_atom=False)},
     )
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -21,7 +21,7 @@ def test_torchscript():
     model = torch.jit.script(model)
 
     system = System(
-        types=[6, 1, 8, 7],
+        types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
         ),
@@ -47,7 +47,7 @@ def test_torchscript_with_identity():
     model = torch.jit.script(model)
 
     system = System(
-        types=[6, 1, 8, 7],
+        types=torch.tensor([6, 1, 8, 7]),
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
         ),

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -1,8 +1,6 @@
-import copy
-
-import ase
 import torch
-from metatensor.torch.atomistic import systems_to_torch
+from metatensor.torch.atomistic import System
+import copy
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -21,12 +19,13 @@ def test_torchscript():
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
     model = torch.jit.script(model)
 
-    system = ase.Atoms(
-        "OHCN",
-        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+    system = System(
+        atomic_types = [6, 1, 8, 7],
+        positions = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]),
+        cell=torch.zeros(3, 3),
     )
     model(
-        [systems_to_torch(system)],
+        [system],
         {"energy": model.outputs["energy"]},
     )
 
@@ -44,12 +43,14 @@ def test_torchscript_with_identity():
     model = SoapBpnn(hypers, dataset_info)
     model = torch.jit.script(model)
 
-    system = ase.Atoms(
-        "OHCN",
-        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+
+    system = System(
+        atomic_types = [6, 1, 8, 7],
+        positions = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+        cell=torch.zeros(3, 3),
     )
     model(
-        [systems_to_torch(system)],
+        [system],
         {"energy": model.outputs["energy"]},
     )
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -1,6 +1,7 @@
+import copy
+
 import torch
 from metatensor.torch.atomistic import System
-import copy
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo, TargetInfo, TargetInfoDict
@@ -20,8 +21,10 @@ def test_torchscript():
     model = torch.jit.script(model)
 
     system = System(
-        atomic_types = [6, 1, 8, 7],
-        positions = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]),
+        atomic_types=[6, 1, 8, 7],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
+        ),
         cell=torch.zeros(3, 3),
     )
     model(
@@ -43,10 +46,11 @@ def test_torchscript_with_identity():
     model = SoapBpnn(hypers, dataset_info)
     model = torch.jit.script(model)
 
-
     system = System(
-        atomic_types = [6, 1, 8, 7],
-        positions = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+        atomic_types=[6, 1, 8, 7],
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
+        ),
         cell=torch.zeros(3, 3),
     )
     model(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -21,7 +21,7 @@ def test_torchscript():
     model = torch.jit.script(model)
 
     system = System(
-        atomic_types=[6, 1, 8, 7],
+        types=[6, 1, 8, 7],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
         ),
@@ -47,7 +47,7 @@ def test_torchscript_with_identity():
     model = torch.jit.script(model)
 
     system = System(
-        atomic_types=[6, 1, 8, 7],
+        types=[6, 1, 8, 7],
         positions=torch.tensor(
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
         ),

--- a/tests/utils/test_evaluate_model.py
+++ b/tests/utils/test_evaluate_model.py
@@ -16,9 +16,7 @@ from . import MODEL_HYPERS, RESOURCES_PATH
 def test_evaluate_model(training, exported):
     """Test that the evaluate_model function works as intended."""
 
-    systems = read_systems(
-        RESOURCES_PATH / "alchemical_reduced_10.xyz", dtype=torch.get_default_dtype()
-    )[:2]
+    systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
     atomic_types = set(
         torch.unique(torch.concatenate([system.types for system in systems]))


### PR DESCRIPTION
Uses `System` instead of `ase.Atoms` in the tests. Closes #167.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--238.org.readthedocs.build/en/238/

<!-- readthedocs-preview metatrain end -->