### PR TITLE
Verify for unknown architecture fields

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,10 +7,9 @@ coverage:
       default:
         target: 90%
   ignore:
-     - "tests/.*"
-     - "examples/.*"
-     - "src/metatrain/experimental/.*"
-     - "src/metatrain/utils/distributed/.*"
-
+    - "tests/.*"
+    - "examples/.*"
+    - "src/metatrain/experimental/.*"
+    - "src/metatrain/utils/distributed/.*"
 
 comment: false

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,12 +15,10 @@ build:
     pre_build:
       - set -e && cd examples/ase && bash train.sh
 
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/src/conf.py
   fail_on_warning: true
-
 
 # Declare the Python requirements required to build the docs.
 # Additionally, a custom environment variable
@@ -28,9 +26,9 @@ sphinx:
 # is declared in the project’s dashboard
 python:
   install:
-  - method: pip
-    path: .
-    extra_requirements:
-      - gap
-      - soap-bpnn
-  - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - gap
+        - soap-bpnn
+    - requirements: docs/requirements.txt

--- a/docs/src/dev-docs/architecture-life-cycle.rst
+++ b/docs/src/dev-docs/architecture-life-cycle.rst
@@ -44,7 +44,8 @@ Transitioning from an experimental to a stable model requires additional criteri
 satisfied:
 
 1. Provision of regression prediction tests with a small (not exported) checkpoint file.
-2. Comprehensive architecture documentation
+2. Comprehensive architecture documentation including a schema for verifying the
+   architecture's hyperparameters.
 3. If an architecture has external dependencies, all must be publicly available on PyPI.
 4. Adherence to the standard output infrastructure of `metatrain`, including
    logging and model save locations.

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -3,7 +3,7 @@
 Adding a new architecture
 =========================
 
-To work with` metatrain` any architecture has to follow the same public API to
+To work with `metatrain` any architecture has to follow the same public API to
 be called correctly within the :py:func:`metatrain.cli.train` function to
 process the user's options. In brief, the core of the ``train`` function looks similar
 to these lines

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -3,10 +3,14 @@
 Adding a new architecture
 =========================
 
-To work with `metatrain` any architecture has to follow the same public API to
-be called correctly within the :py:func:`metatrain.cli.train` function to
-process the user's options. In brief, the core of the ``train`` function looks similar
-to these lines
+This page describes the required classes and files necessary for adding a new
+architecture to `metatrain` as experimental or stable architecture as described on the
+:ref:`architecture-life-cycle` page. For **examples** refer to the already existing
+architectures inside the source tree.
+
+To work with `metatrain` any architecture has to follow the same public API to be called
+correctly within the :py:func:`metatrain.cli.train` function to process the user's
+options. In brief, the core of the ``train`` function looks similar to these lines
 
 .. code-block:: python
 
@@ -38,7 +42,7 @@ to these lines
     mts_atomistic_model.export("model.pt", collect_extensions="extensions/")
 
 
-In order to follow this, a new architectures has two define two classes
+To follow this, a new architecture has to define two classes
 
 - a ``Model`` class, defining the core of the architecture. This class must implement
   the interface documented below in :py:class:`ModelInterface`
@@ -48,16 +52,38 @@ In order to follow this, a new architectures has two define two classes
 
 .. note::
 
-    ``metatrain`` does not know the types and numbers of targets/datasets that
-    an architecture can handle. As a result, it cannot generate useful error messages
-    when a user attempts to train an architecture with unsupported target and dataset
+    ``metatrain`` does not know the types and numbers of targets/datasets an
+    architecture can handle. As a result, it cannot generate useful error messages when
+    a user attempts to train an architecture with unsupported target and dataset
     combinations. Therefore, it is the responsibility of the architecture developer to
     verify if the model and the trainer support the provided train_datasets and
-    val_datasets passed to the Trainer, as well as the dataset_info passed to the
-    model.
+    val_datasets passed to the Trainer, as well as the dataset_info passed to the model.
 
-The ``ModelInterface`` is the main model class and must implement the
-``load_checkpoint()``, ``restart()`` and ``export()`` methods.
+To comply with this design each architecture has to implement a couple of files
+inside a new architecture directory, either inside the ``experimental`` subdirectory or
+in the ``root`` of the Python source if the new architecture already complies with all
+requirements to be stable. The usual structure of architecture looks as
+
+.. code-block:: text
+
+    myarchitecture
+        ├── model.py
+        ├── trainer.py
+        ├── __init__.py
+        ├── default-hypers.yaml
+        └── schema-hypers.json
+
+.. note::
+    A new architecture doesn't have to be registered somewhere in the file tree of
+    `metatrain`. Once a new architecture folder with the required files is created
+    `metatrain` will include the architecture automatically.
+
+Model class (``model.py``)
+--------------------------
+The ``ModelInterface``, is recommended to be located in a file called ``model.py``
+inside the architecture folder is the main model class and must implement a
+``save_checkpoint()``, ``load_checkpoint()`` as well as a ``restart()`` and ``export()``
+method.
 
 .. code-block:: python
 
@@ -80,20 +106,20 @@ The ``ModelInterface`` is the main model class and must implement the
             This function is called whenever training restarts, with the same or a
             different dataset.
 
-            It enables transfer learning (changing the targets), and fine tuning (same
-            targets, different dataset)
+            It enables transfer learning (changing the targets), and fine-tuning (same
+            targets, different datasets)
             """
             pass
 
         def export(self) -> MetatensorAtomisticModel:
             pass
 
-Note that the ``ModelInterface`` does not necessary inherit from
+Note that the ``ModelInterface`` does not necessarily inherit from
 :py:class:`torch.nn.Module` since training can be performed in any way.
 ``__supported_devices__`` and ``__supported_dtypes__`` can be defined to set the
 capabilities of the model. These two lists should be sorted in order of preference since
 `metatrain` will use these to determine, based on the user request and
-machines's availability, the optimal `dtype` and `device` for training.
+machines' availability, the optimal `dtype` and `device` for training.
 
 The ``export()`` method is required to transform a trained model into a standalone file
 to be used in combination with molecular dynamic engines to run simulations. We provide
@@ -101,6 +127,8 @@ a helper function :py:func:`metatrain.utils.export.export` to export a torch
 model to an :py:class:`MetatensorAtomisticModel
 <metatensor.torch.atomistic.MetatensorAtomisticModel>`.
 
+Trainer class (``trainer.py``)
+------------------------------
 The ``TrainerInterface`` class should have the following signature with required
 methods for ``train()``, ``save_checkpoint()`` and ``load_checkpoint()``.
 
@@ -131,6 +159,8 @@ The format of checkpoints is not defined by `metatrain` and can be any format th
 can be loaded by the trainer (to restart training) and by the model (to export the
 checkpoint).
 
+Init file (``__init__.py``)
+---------------------------
 The names of the ``ModelInterface`` and the ``TrainerInterface`` are free to choose but
 should be linked to constants in the ``__init__.py`` of each architecture. On top of
 these two constants the ``__init__.py`` must contain constants for the original
@@ -151,12 +181,46 @@ these two constants the ``__init__.py`` must contain constants for the original
 
     __maintainers__ = [("Joe Bloggs <joe.bloggs@sotacompany.com>", "@joebloggs")]
 
-
 :param __model__: Mapping of the custom ``ModelInterface`` to a general one to be loaded
     by ``metatrain``.
 :param __trainer__: Same as ``__MODEL_CLASS__`` but the Trainer class.
-:param __authors__: Tuple denoting the original authors with email address and Github
-    handle of an architecture. These do not necessary be in charge of maintaining the
-    the architecture.
+:param __authors__: Tuple denoting the original authors with an email address and GitHub
+    handle of an architecture. These do not necessarily be in charge of maintaining the
+    architecture.
 :param __maintainers__: Tuple denoting the current maintainers of the architecture. Uses
     the same style as the ``__authors__`` constant.
+
+
+Default Hyperparamers (``default-hypers.yaml``)
+-----------------------------------------------
+The default hyperparameters for each architecture should be stored in a YAML file
+``default-hypers.yaml`` inside the architecture directory. Reasonable default hypers are
+required to improve usability. The default hypers must follow the structure
+
+.. code-block:: yaml
+
+    name: myarchitecture
+
+    model:
+        ...
+
+    training:
+        ...
+
+`metatrain` will parse this file and overwrite these default hypers with the
+user-provided parameters and pass the merged ``model`` section as a Python dictionary to
+the ``ModelInterface`` and the ``training`` section to the ``TrainerInterface``.
+
+JSON schema (``schema-hypers.yaml``)
+------------------------------------
+To validate the user's input hyperparameters we are using `JSON schemas
+<https://json-schema.org/>`_ stored in a schema file called ``schema-hypers.json``. For
+an :ref:`experimental architecture <architecture-life-cycle>` it is not required to
+provide such a schema along with its default hypers but it is highly recommended to
+reduce possible errors of user input like typos in parameter names or wrong sections. If
+no ``schema-hypers.json`` is provided no validation is performed and user hypers are
+passed to the architecture model and trainer as is.
+
+To create such a schema start by using `online tools <https://jsonformatter.org>`_ that
+convert the ``default-hypers.yaml`` into a JSON schema. Besides online tools, we also
+had success using ChatGPT/LLM for this for conversion.

--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -122,6 +122,9 @@ Each gradient section (like ``forces`` or ``stress``) has similar parameters:
 :param file_format: The file format, guessed from the suffix if not provided.
 :param key: The key for reading from the file.
 
+A single string in a gradient section automatically expands, using the string as the
+``read_from`` parameter.
+
 Sections set to ``true`` or ``on`` automatically expand with default parameters. A
 warning is raised if requisite data for a gradient is missing, but training proceeds
 without them.

--- a/docs/static/qm9/options.yaml
+++ b/docs/static/qm9/options.yaml
@@ -2,16 +2,16 @@
 architecture:
   name: experimental.soap_bpnn
   training:
-    num_epochs: 5  # a very short training run
+    num_epochs: 5 # a very short training run
 
 # Mandatory section defining the parameters for system and target data of the
 # training set
 training_set:
-  systems: "qm9_reduced_100.xyz"  # file where the positions are stored
+  systems: "qm9_reduced_100.xyz" # file where the positions are stored
   targets:
     energy:
-      key: "U0"  # name of the target value
-      unit: "eV"  # unit of the target value
+      key: "U0" # name of the target value
+      unit: "eV" # unit of the target value
 
-test_set: 0.1  # 10 % of the training_set are randomly split and taken for test set
-validation_set: 0.1  # 10 % of the training_set are randomly split and for validation
+test_set: 0.1 # 10 % of the training_set are randomly split and taken for test set
+validation_set: 0.1 # 10 % of the training_set are randomly split and for validation

--- a/examples/ase/options.yaml
+++ b/examples/ase/options.yaml
@@ -7,7 +7,7 @@ training_set:
   targets:
     energy:
       key: "energy"
-      unit: "kcal/mol"  # very important to run simulations
+      unit: "kcal/mol" # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "metatensor-learn==0.2.2",
     "metatensor-operations==0.2.1",
     "metatensor-torch==0.5.1",
+    "jsonschema",
     "omegaconf",
     "python-hostlist",
     "torch",

--- a/src/metatrain/__main__.py
+++ b/src/metatrain/__main__.py
@@ -8,7 +8,7 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 
-from . import __version__
+from . import PACKAGE_ROOT, __version__
 from .cli.eval import _add_eval_model_parser, _prepare_eval_model_args, eval_model
 from .cli.export import (
     _add_export_model_parser,
@@ -58,7 +58,7 @@ def main():
         "--shell-completion",
         action="version",
         help="Path to the shell completion script",
-        version=str(Path(__file__).parent / "share/metatrain-completion.bash"),
+        version=str(PACKAGE_ROOT / "share/metatrain-completion.bash"),
     )
 
     # Add sub-parsers

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -1,17 +1,19 @@
 import argparse
 import importlib
+import json
 import logging
 import os
 import random
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+import jsonschema
 import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
-from omegaconf.errors import ConfigKeyError
 
-from ..utils.architectures import check_architecture_name, get_default_hypers
+from .. import PACKAGE_ROOT
+from ..utils.architectures import check_architecture_options, get_default_hypers
 from ..utils.data import (
     Dataset,
     DatasetInfo,
@@ -25,12 +27,7 @@ from ..utils.devices import pick_devices
 from ..utils.distributed.logging import is_main_process
 from ..utils.errors import ArchitectureError
 from ..utils.io import check_suffix
-from ..utils.omegaconf import (
-    BASE_OPTIONS,
-    check_options_list,
-    check_units,
-    expand_dataset_config,
-)
+from ..utils.omegaconf import BASE_OPTIONS, check_units, expand_dataset_config
 from .eval import _eval_targets
 from .formatter import CustomHelpFormatter
 
@@ -118,22 +115,32 @@ def train_model(
     :param continue_from: File to continue training from.
     """
     ###########################
+    # VALIDATE BASE OPTIONS ###
+    ###########################
+
+    # Training, test and validation set options are verified within the
+    # `expand_dataset_config()` function.
+
+    with open(PACKAGE_ROOT / "share/schema-base.json", "r") as f:
+        schema_base = json.load(f)
+
+    jsonschema.validate(instance=OmegaConf.to_container(options), schema=schema_base)
+
+    ###########################
     # LOAD ARCHITECTURE #######
     ###########################
 
-    try:
-        architecture_name = options["architecture"]["name"]
-    except ConfigKeyError as exc:
-        raise ValueError("Architecture name is not defined!") from exc
-
-    check_architecture_name(architecture_name)
+    architecture_name = options["architecture"]["name"]
+    check_architecture_options(
+        name=architecture_name, options=OmegaConf.to_container(options["architecture"])
+    )
     architecture = importlib.import_module(f"metatrain.{architecture_name}")
 
     Model = architecture.__model__
     Trainer = architecture.__trainer__
 
     ###########################
-    # CREATE OPTIONS ##########
+    # MERGE OPTIONS ###########
     ###########################
 
     options = OmegaConf.merge(
@@ -154,14 +161,7 @@ def train_model(
     )
 
     # process base_precision/dtypes
-    if options["base_precision"] == 64:
-        dtype = torch.float64
-    elif options["base_precision"] == 32:
-        dtype = torch.float32
-    elif options["base_precision"] == 16:
-        dtype = torch.float16
-    else:
-        raise ValueError("Only 64, 32 or 16 are possible values for `base_precision`.")
+    dtype = getattr(torch, f"float{options['base_precision']}")
 
     if dtype not in Model.__supported_dtypes__:
         raise ValueError(
@@ -170,29 +170,25 @@ def train_model(
         )
 
     # process random seeds
-    if options["seed"] < 0:
-        raise ValueError("`seed` should be a positive number")
-    else:
-        logger.info(f"Random seed of this run is {options['seed']}")
-        torch.manual_seed(options["seed"])
-        np.random.seed(options["seed"])
-        random.seed(options["seed"])
-        os.environ["PYTHONHASHSEED"] = str(options["seed"])
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed(options["seed"])
-            torch.cuda.manual_seed_all(options["seed"])
+    logger.info(f"Random seed of this run is {options['seed']}")
+    torch.manual_seed(options["seed"])
+    np.random.seed(options["seed"])
+    random.seed(options["seed"])
+    os.environ["PYTHONHASHSEED"] = str(options["seed"])
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(options["seed"])
+        torch.cuda.manual_seed_all(options["seed"])
 
     ###########################
     # SETUP TRAINING SET ######
     ###########################
 
     logger.info("Setting up training set")
-    train_options_list = expand_dataset_config(options["training_set"])
-    check_options_list(train_options_list)
+    options["training_set"] = expand_dataset_config(options["training_set"])
 
     train_datasets = []
     target_infos = TargetInfoDict()
-    for train_options in train_options_list:
+    for train_options in options["training_set"]:
         train_systems = read_systems(
             filename=train_options["systems"]["read_from"],
             fileformat=train_options["systems"]["file_format"],
@@ -212,16 +208,10 @@ def train_model(
     ###########################
 
     logger.info("Setting up test set")
-    test_options = options["test_set"]
     test_datasets = []
-    if isinstance(test_options, float):
-        test_size = test_options
+    if isinstance(options["test_set"], float):
+        test_size = options["test_set"]
         train_size -= test_size
-
-        if test_size < 0 or test_size >= 1:
-            raise ValueError(
-                "Test set split must be greater or equal than 0 and lesser than 1."
-            )
 
         generator = torch.Generator()
         if options["seed"] is not None:
@@ -238,20 +228,21 @@ def train_model(
             train_datasets[i_dataset] = train_dataset_new
             test_datasets.append(test_dataset)
     else:
-        test_options_list = expand_dataset_config(test_options)
-        check_options_list(test_options_list)
+        options["test_set"] = expand_dataset_config(options["test_set"])
 
-        if len(test_options_list) != len(train_options_list):
+        if len(options["test_set"]) != len(options["training_set"]):
             raise ValueError(
-                f"Test dataset with length {len(test_options_list)} has a different "
-                f"size than the train datatset with length {len(train_options_list)}."
+                f"Test dataset with length {len(options['test_set'])} has a different "
+                f"size than the training datatset with length "
+                f"{len(options['training_set'])}."
             )
 
         check_units(
-            actual_options=test_options_list, desired_options=train_options_list
+            actual_options=options["test_set"],
+            desired_options=options["training_set"],
         )
 
-        for test_options in test_options_list:
+        for test_options in options["test_set"]:
             test_systems = read_systems(
                 filename=test_options["systems"]["read_from"],
                 fileformat=test_options["systems"]["file_format"],
@@ -266,16 +257,10 @@ def train_model(
     ###########################
 
     logger.info("Setting up validation set")
-    val_options = options["validation_set"]
     val_datasets = []
-    if isinstance(val_options, float):
-        val_size = val_options
+    if isinstance(options["validation_set"], float):
+        val_size = options["validation_set"]
         train_size -= val_size
-
-        if val_size <= 0 or val_size >= 1:
-            raise ValueError(
-                "Validation set split must be greater than 0 and lesser than 1."
-            )
 
         generator = torch.Generator()
         if options["seed"] is not None:
@@ -292,19 +277,21 @@ def train_model(
             train_datasets[i_dataset] = train_dataset_new
             val_datasets.append(val_dataset)
     else:
-        val_options_list = expand_dataset_config(val_options)
-        check_options_list(val_options_list)
+        options["validation_set"] = expand_dataset_config(options["validation_set"])
 
-        if len(val_options_list) != len(train_options_list):
+        if len(options["validation_set"]) != len(options["training_set"]):
             raise ValueError(
-                f"Validation dataset with length {len(val_options_list)} has "
-                "a different size than the train datatset with length "
-                f"{len(train_options_list)}."
+                f"Validation dataset with length {len(options['validation_set'])} has "
+                "a different size than the training datatset with length "
+                f"{len(options['training_set'])}."
             )
 
-        check_units(actual_options=val_options_list, desired_options=train_options_list)
+        check_units(
+            actual_options=options["validation_set"],
+            desired_options=options["training_set"],
+        )
 
-        for val_options in val_options_list:
+        for val_options in options["validation_set"]:
             val_systems = read_systems(
                 filename=val_options["systems"]["read_from"],
                 fileformat=val_options["systems"]["file_format"],
@@ -321,7 +308,7 @@ def train_model(
     atomic_types = get_atomic_types(train_datasets + val_datasets)
 
     dataset_info = DatasetInfo(
-        length_unit=train_options_list[0]["systems"]["length_unit"],
+        length_unit=options["training_set"][0]["systems"]["length_unit"],
         atomic_types=atomic_types,
         targets=target_infos,
     )

--- a/src/metatrain/experimental/alchemical_model/default-hypers.yaml
+++ b/src/metatrain/experimental/alchemical_model/default-hypers.yaml
@@ -5,7 +5,7 @@ model:
     num_pseudo_species: 4
     cutoff: 5.0
     basis_cutoff_power_spectrum: 400
-    radial_basis_type: 'physical'
+    radial_basis_type: "physical"
     basis_scale: 3.0
     trainable_basis: true
     normalize: true
@@ -20,7 +20,7 @@ training:
   learning_rate: 0.001
   early_stopping_patience: 50
   scheduler_patience: 10
-  scheduler_factor: 0.8  
+  scheduler_factor: 0.8
   log_interval: 5
   checkpoint_interval: 25
   per_structure_targets: []

--- a/src/metatrain/experimental/alchemical_model/default-hypers.yaml
+++ b/src/metatrain/experimental/alchemical_model/default-hypers.yaml
@@ -1,3 +1,5 @@
+name: experimental.alchemical_model
+
 model:
   soap:
     num_pseudo_species: 4

--- a/src/metatrain/experimental/alchemical_model/schema-hypers.json
+++ b/src/metatrain/experimental/alchemical_model/schema-hypers.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "enum": ["experimental.alchemical_model"]
+          },
+        "model": {
+            "type": "object",
+            "properties": {
+                "soap": {
+                    "type": "object",
+                    "properties": {
+                        "num_pseudo_species": {
+                            "type": "integer"
+                        },
+                        "cutoff": {
+                            "type": "number"
+                        },
+                        "basis_cutoff_power_spectrum": {
+                            "type": "integer"
+                        },
+                        "radial_basis_type": {
+                            "type": "string"
+                        },
+                        "basis_scale": {
+                            "type": "number"
+                        },
+                        "trainable_basis": {
+                            "type": "boolean"
+                        },
+                        "normalize": {
+                            "type": "boolean"
+                        },
+                        "contract_center_species": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "bpnn": {
+                    "type": "object",
+                    "properties": {
+                        "hidden_sizes": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "output_size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "training": {
+            "type": "object",
+            "properties": {
+                "batch_size": {
+                    "type": "integer"
+                },
+                "num_epochs": {
+                    "type": "integer"
+                },
+                "learning_rate": {
+                    "type": "number"
+                },
+                "early_stopping_patience": {
+                    "type": "integer"
+                },
+                "scheduler_patience": {
+                    "type": "integer"
+                },
+                "scheduler_factor": {
+                    "type": "number"
+                },
+                "log_interval": {
+                    "type": "integer"
+                },
+                "checkpoint_interval": {
+                    "type": "integer"
+                },
+                "per_structure_targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "loss_weights": {
+                    "type": "object",
+                    "properties": {
+                        "energy": {
+                            "type": "number"
+                        },
+                        "forces": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/metatrain/experimental/alchemical_model/schema-hypers.json
+++ b/src/metatrain/experimental/alchemical_model/schema-hypers.json
@@ -1,110 +1,110 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "enum": ["experimental.alchemical_model"]
-          },
-        "model": {
-            "type": "object",
-            "properties": {
-                "soap": {
-                    "type": "object",
-                    "properties": {
-                        "num_pseudo_species": {
-                            "type": "integer"
-                        },
-                        "cutoff": {
-                            "type": "number"
-                        },
-                        "basis_cutoff_power_spectrum": {
-                            "type": "integer"
-                        },
-                        "radial_basis_type": {
-                            "type": "string"
-                        },
-                        "basis_scale": {
-                            "type": "number"
-                        },
-                        "trainable_basis": {
-                            "type": "boolean"
-                        },
-                        "normalize": {
-                            "type": "boolean"
-                        },
-                        "contract_center_species": {
-                            "type": "boolean"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "bpnn": {
-                    "type": "object",
-                    "properties": {
-                        "hidden_sizes": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer"
-                            }
-                        },
-                        "output_size": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        },
-        "training": {
-            "type": "object",
-            "properties": {
-                "batch_size": {
-                    "type": "integer"
-                },
-                "num_epochs": {
-                    "type": "integer"
-                },
-                "learning_rate": {
-                    "type": "number"
-                },
-                "early_stopping_patience": {
-                    "type": "integer"
-                },
-                "scheduler_patience": {
-                    "type": "integer"
-                },
-                "scheduler_factor": {
-                    "type": "number"
-                },
-                "log_interval": {
-                    "type": "integer"
-                },
-                "checkpoint_interval": {
-                    "type": "integer"
-                },
-                "per_structure_targets": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "loss_weights": {
-                    "type": "object",
-                    "properties": {
-                        "energy": {
-                            "type": "number"
-                        },
-                        "forces": {
-                            "type": "number"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["experimental.alchemical_model"]
     },
-    "additionalProperties": false
+    "model": {
+      "type": "object",
+      "properties": {
+        "soap": {
+          "type": "object",
+          "properties": {
+            "num_pseudo_species": {
+              "type": "integer"
+            },
+            "cutoff": {
+              "type": "number"
+            },
+            "basis_cutoff_power_spectrum": {
+              "type": "integer"
+            },
+            "radial_basis_type": {
+              "type": "string"
+            },
+            "basis_scale": {
+              "type": "number"
+            },
+            "trainable_basis": {
+              "type": "boolean"
+            },
+            "normalize": {
+              "type": "boolean"
+            },
+            "contract_center_species": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "bpnn": {
+          "type": "object",
+          "properties": {
+            "hidden_sizes": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "output_size": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "training": {
+      "type": "object",
+      "properties": {
+        "batch_size": {
+          "type": "integer"
+        },
+        "num_epochs": {
+          "type": "integer"
+        },
+        "learning_rate": {
+          "type": "number"
+        },
+        "early_stopping_patience": {
+          "type": "integer"
+        },
+        "scheduler_patience": {
+          "type": "integer"
+        },
+        "scheduler_factor": {
+          "type": "number"
+        },
+        "log_interval": {
+          "type": "integer"
+        },
+        "checkpoint_interval": {
+          "type": "integer"
+        },
+        "per_structure_targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "loss_weights": {
+          "type": "object",
+          "properties": {
+            "energy": {
+              "type": "number"
+            },
+            "forces": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/metatrain/experimental/gap/default-hypers.yaml
+++ b/src/metatrain/experimental/gap/default-hypers.yaml
@@ -1,5 +1,4 @@
-# default hyperparameters for the SparseGAP model
-name: gap
+name: experimental.gap
 
 model:
   soap:

--- a/src/metatrain/experimental/gap/schema-hypers.json
+++ b/src/metatrain/experimental/gap/schema-hypers.json
@@ -1,115 +1,115 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "enum": ["experimental.gap"]
-          },
-        "model": {
-            "type": "object",
-            "properties": {
-                "soap": {
-                    "type": "object",
-                    "properties": {
-                        "cutoff": {
-                            "type": "number"
-                        },
-                        "max_radial": {
-                            "type": "integer"
-                        },
-                        "max_angular": {
-                            "type": "integer"
-                        },
-                        "atomic_gaussian_width": {
-                            "type": "number"
-                        },
-                        "radial_basis": {
-                            "type": "object",
-                            "properties": {
-                                "Gto": {
-                                    "type": "object",
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "center_atom_weight": {
-                            "type": "number"
-                        },
-                        "cutoff_function": {
-                            "type": "object",
-                            "properties": {
-                                "ShiftedCosine": {
-                                    "type": "object",
-                                    "properties": {
-                                        "width": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "radial_scaling": {
-                            "type": "object",
-                            "properties": {
-                                "Willatt2018": {
-                                    "type": "object",
-                                    "properties": {
-                                        "rate": {
-                                            "type": "number"
-                                        },
-                                        "scale": {
-                                            "type": "number"
-                                        },
-                                        "exponent": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "krr": {
-                    "type": "object",
-                    "properties": {
-                        "degree": {
-                            "type": "integer"
-                        },
-                        "num_sparse_points": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        },
-        "training": {
-            "type": "object",
-            "properties": {
-                "regularizer": {
-                    "type": "number"
-                },
-                "regularizer_forces": {
-                    "oneOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "additionalProperties": false
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["experimental.gap"]
     },
-    "additionalProperties": false
+    "model": {
+      "type": "object",
+      "properties": {
+        "soap": {
+          "type": "object",
+          "properties": {
+            "cutoff": {
+              "type": "number"
+            },
+            "max_radial": {
+              "type": "integer"
+            },
+            "max_angular": {
+              "type": "integer"
+            },
+            "atomic_gaussian_width": {
+              "type": "number"
+            },
+            "radial_basis": {
+              "type": "object",
+              "properties": {
+                "Gto": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "center_atom_weight": {
+              "type": "number"
+            },
+            "cutoff_function": {
+              "type": "object",
+              "properties": {
+                "ShiftedCosine": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "radial_scaling": {
+              "type": "object",
+              "properties": {
+                "Willatt2018": {
+                  "type": "object",
+                  "properties": {
+                    "rate": {
+                      "type": "number"
+                    },
+                    "scale": {
+                      "type": "number"
+                    },
+                    "exponent": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "krr": {
+          "type": "object",
+          "properties": {
+            "degree": {
+              "type": "integer"
+            },
+            "num_sparse_points": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "training": {
+      "type": "object",
+      "properties": {
+        "regularizer": {
+          "type": "number"
+        },
+        "regularizer_forces": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/metatrain/experimental/gap/schema-hypers.json
+++ b/src/metatrain/experimental/gap/schema-hypers.json
@@ -1,0 +1,115 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "enum": ["experimental.gap"]
+          },
+        "model": {
+            "type": "object",
+            "properties": {
+                "soap": {
+                    "type": "object",
+                    "properties": {
+                        "cutoff": {
+                            "type": "number"
+                        },
+                        "max_radial": {
+                            "type": "integer"
+                        },
+                        "max_angular": {
+                            "type": "integer"
+                        },
+                        "atomic_gaussian_width": {
+                            "type": "number"
+                        },
+                        "radial_basis": {
+                            "type": "object",
+                            "properties": {
+                                "Gto": {
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "center_atom_weight": {
+                            "type": "number"
+                        },
+                        "cutoff_function": {
+                            "type": "object",
+                            "properties": {
+                                "ShiftedCosine": {
+                                    "type": "object",
+                                    "properties": {
+                                        "width": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "radial_scaling": {
+                            "type": "object",
+                            "properties": {
+                                "Willatt2018": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rate": {
+                                            "type": "number"
+                                        },
+                                        "scale": {
+                                            "type": "number"
+                                        },
+                                        "exponent": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "krr": {
+                    "type": "object",
+                    "properties": {
+                        "degree": {
+                            "type": "integer"
+                        },
+                        "num_sparse_points": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "training": {
+            "type": "object",
+            "properties": {
+                "regularizer": {
+                    "type": "number"
+                },
+                "regularizer_forces": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/metatrain/experimental/pet/default-hypers.yaml
+++ b/src/metatrain/experimental/pet/default-hypers.yaml
@@ -29,8 +29,7 @@ model:
   K_CUT: null # should be float; only used when USE_LONG_RANGE is True
   RESIDUAL_FACTOR: 0.5
 
-
-training:  
+training:
   INITIAL_LR: 1e-4
   EPOCH_NUM_ATOMIC: 1000000000000000000
   SCHEDULER_STEP_SIZE_ATOMIC: 500000000

--- a/src/metatrain/experimental/pet/default-hypers.yaml
+++ b/src/metatrain/experimental/pet/default-hypers.yaml
@@ -1,3 +1,5 @@
+name: experimental.pet
+
 model:
   CUTOFF_DELTA: 0.2
   AVERAGE_POOLING: False
@@ -48,5 +50,5 @@ training:
   DO_GRADIENT_CLIPPING: False
   GRADIENT_CLIPPING_MAX_NORM: null # must be overwritten if DO_GRADIENT_CLIPPING is True
   USE_SHIFT_AGNOSTIC_LOSS: False # only used when fitting general target. Primary use case: EDOS
-  ENERGIES_LOSS: per_structure # per_structure or per_atom
+  ENERGIES_LOSS: per_structure # or per_atom
   BALANCED_DATA_LOADER: False

--- a/src/metatrain/experimental/pet/schema-hypers.json
+++ b/src/metatrain/experimental/pet/schema-hypers.json
@@ -1,0 +1,199 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "enum": ["experimental.pet"]
+          },
+        "model": {
+            "type": "object",
+            "properties": {
+                "CUTOFF_DELTA": {
+                    "type": "number"
+                },
+                "AVERAGE_POOLING": {
+                    "type": "boolean"
+                },
+                "TRANSFORMERS_CENTRAL_SPECIFIC": {
+                    "type": "boolean"
+                },
+                "HEADS_CENTRAL_SPECIFIC": {
+                    "type": "boolean"
+                },
+                "ADD_TOKEN_FIRST": {
+                    "type": "boolean"
+                },
+                "ADD_TOKEN_SECOND": {
+                    "type": "boolean"
+                },
+                "N_GNN_LAYERS": {
+                    "type": "integer"
+                },
+                "TRANSFORMER_D_MODEL": {
+                    "type": "integer"
+                },
+                "TRANSFORMER_N_HEAD": {
+                    "type": "integer"
+                },
+                "TRANSFORMER_DIM_FEEDFORWARD": {
+                    "type": "integer"
+                },
+                "HEAD_N_NEURONS": {
+                    "type": "integer"
+                },
+                "N_TRANS_LAYERS": {
+                    "type": "integer"
+                },
+                "ACTIVATION": {
+                    "type": "string"
+                },
+                "USE_LENGTH": {
+                    "type": "boolean"
+                },
+                "USE_ONLY_LENGTH": {
+                    "type": "boolean"
+                },
+                "R_CUT": {
+                    "type": "number"
+                },
+                "R_EMBEDDING_ACTIVATION": {
+                    "type": "boolean"
+                },
+                "COMPRESS_MODE": {
+                    "type": "string"
+                },
+                "BLEND_NEIGHBOR_SPECIES": {
+                    "type": "boolean"
+                },
+                "AVERAGE_BOND_ENERGIES": {
+                    "type": "boolean"
+                },
+                "USE_BOND_ENERGIES": {
+                    "type": "boolean"
+                },
+                "USE_ADDITIONAL_SCALAR_ATTRIBUTES": {
+                    "type": "boolean"
+                },
+                "SCALAR_ATTRIBUTES_SIZE": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "TRANSFORMER_TYPE": {
+                    "type": "string"
+                },
+                "USE_LONG_RANGE": {
+                    "type": "boolean"
+                },
+                "K_CUT": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "RESIDUAL_FACTOR": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false
+        },
+        "training": {
+            "type": "object",
+            "properties": {
+                "INITIAL_LR": {
+                    "type": "number"
+                },
+                "EPOCH_NUM_ATOMIC": {
+                    "type": "integer"
+                },
+                "SCHEDULER_STEP_SIZE_ATOMIC": {
+                    "type": "integer"
+                },
+                "EPOCHS_WARMUP_ATOMIC": {
+                    "type": "integer"
+                },
+                "GLOBAL_AUG": {
+                    "type": "boolean"
+                },
+                "SLIDING_FACTOR": {
+                    "type": "number"
+                },
+                "ATOMIC_BATCH_SIZE": {
+                    "type": "integer"
+                },
+                "MAX_TIME": {
+                    "type": "integer"
+                },
+                "ENERGY_WEIGHT": {
+                    "type": "number"
+                },
+                "MULTI_GPU": {
+                    "type": "boolean"
+                },
+                "RANDOM_SEED": {
+                    "type": "integer"
+                },
+                "CUDA_DETERMINISTIC": {
+                    "type": "boolean"
+                },
+                "MODEL_TO_START_WITH": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "SUPPORT_MISSING_VALUES": {
+                    "type": "boolean"
+                },
+                "USE_WEIGHT_DECAY": {
+                    "type": "boolean"
+                },
+                "WEIGHT_DECAY": {
+                    "type": "number"
+                },
+                "DO_GRADIENT_CLIPPING": {
+                    "type": "boolean"
+                },
+                "GRADIENT_CLIPPING_MAX_NORM": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "USE_SHIFT_AGNOSTIC_LOSS": {
+                    "type": "boolean"
+                },
+                "ENERGIES_LOSS": {
+                    "type": "string",
+                    "enum": [
+                        "per_structure",
+                        "per_atom"
+                    ]
+                },
+                "BALANCED_DATA_LOADER": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/metatrain/experimental/pet/schema-hypers.json
+++ b/src/metatrain/experimental/pet/schema-hypers.json
@@ -1,199 +1,196 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "enum": ["experimental.pet"]
-          },
-        "model": {
-            "type": "object",
-            "properties": {
-                "CUTOFF_DELTA": {
-                    "type": "number"
-                },
-                "AVERAGE_POOLING": {
-                    "type": "boolean"
-                },
-                "TRANSFORMERS_CENTRAL_SPECIFIC": {
-                    "type": "boolean"
-                },
-                "HEADS_CENTRAL_SPECIFIC": {
-                    "type": "boolean"
-                },
-                "ADD_TOKEN_FIRST": {
-                    "type": "boolean"
-                },
-                "ADD_TOKEN_SECOND": {
-                    "type": "boolean"
-                },
-                "N_GNN_LAYERS": {
-                    "type": "integer"
-                },
-                "TRANSFORMER_D_MODEL": {
-                    "type": "integer"
-                },
-                "TRANSFORMER_N_HEAD": {
-                    "type": "integer"
-                },
-                "TRANSFORMER_DIM_FEEDFORWARD": {
-                    "type": "integer"
-                },
-                "HEAD_N_NEURONS": {
-                    "type": "integer"
-                },
-                "N_TRANS_LAYERS": {
-                    "type": "integer"
-                },
-                "ACTIVATION": {
-                    "type": "string"
-                },
-                "USE_LENGTH": {
-                    "type": "boolean"
-                },
-                "USE_ONLY_LENGTH": {
-                    "type": "boolean"
-                },
-                "R_CUT": {
-                    "type": "number"
-                },
-                "R_EMBEDDING_ACTIVATION": {
-                    "type": "boolean"
-                },
-                "COMPRESS_MODE": {
-                    "type": "string"
-                },
-                "BLEND_NEIGHBOR_SPECIES": {
-                    "type": "boolean"
-                },
-                "AVERAGE_BOND_ENERGIES": {
-                    "type": "boolean"
-                },
-                "USE_BOND_ENERGIES": {
-                    "type": "boolean"
-                },
-                "USE_ADDITIONAL_SCALAR_ATTRIBUTES": {
-                    "type": "boolean"
-                },
-                "SCALAR_ATTRIBUTES_SIZE": {
-                    "oneOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "TRANSFORMER_TYPE": {
-                    "type": "string"
-                },
-                "USE_LONG_RANGE": {
-                    "type": "boolean"
-                },
-                "K_CUT": {
-                    "oneOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "RESIDUAL_FACTOR": {
-                    "type": "number"
-                }
-            },
-            "additionalProperties": false
-        },
-        "training": {
-            "type": "object",
-            "properties": {
-                "INITIAL_LR": {
-                    "type": "number"
-                },
-                "EPOCH_NUM_ATOMIC": {
-                    "type": "integer"
-                },
-                "SCHEDULER_STEP_SIZE_ATOMIC": {
-                    "type": "integer"
-                },
-                "EPOCHS_WARMUP_ATOMIC": {
-                    "type": "integer"
-                },
-                "GLOBAL_AUG": {
-                    "type": "boolean"
-                },
-                "SLIDING_FACTOR": {
-                    "type": "number"
-                },
-                "ATOMIC_BATCH_SIZE": {
-                    "type": "integer"
-                },
-                "MAX_TIME": {
-                    "type": "integer"
-                },
-                "ENERGY_WEIGHT": {
-                    "type": "number"
-                },
-                "MULTI_GPU": {
-                    "type": "boolean"
-                },
-                "RANDOM_SEED": {
-                    "type": "integer"
-                },
-                "CUDA_DETERMINISTIC": {
-                    "type": "boolean"
-                },
-                "MODEL_TO_START_WITH": {
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "SUPPORT_MISSING_VALUES": {
-                    "type": "boolean"
-                },
-                "USE_WEIGHT_DECAY": {
-                    "type": "boolean"
-                },
-                "WEIGHT_DECAY": {
-                    "type": "number"
-                },
-                "DO_GRADIENT_CLIPPING": {
-                    "type": "boolean"
-                },
-                "GRADIENT_CLIPPING_MAX_NORM": {
-                    "oneOf": [
-                        {
-                            "type": "number"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "USE_SHIFT_AGNOSTIC_LOSS": {
-                    "type": "boolean"
-                },
-                "ENERGIES_LOSS": {
-                    "type": "string",
-                    "enum": [
-                        "per_structure",
-                        "per_atom"
-                    ]
-                },
-                "BALANCED_DATA_LOADER": {
-                    "type": "boolean"
-                }
-            },
-            "additionalProperties": false
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["experimental.pet"]
     },
-    "additionalProperties": false
+    "model": {
+      "type": "object",
+      "properties": {
+        "CUTOFF_DELTA": {
+          "type": "number"
+        },
+        "AVERAGE_POOLING": {
+          "type": "boolean"
+        },
+        "TRANSFORMERS_CENTRAL_SPECIFIC": {
+          "type": "boolean"
+        },
+        "HEADS_CENTRAL_SPECIFIC": {
+          "type": "boolean"
+        },
+        "ADD_TOKEN_FIRST": {
+          "type": "boolean"
+        },
+        "ADD_TOKEN_SECOND": {
+          "type": "boolean"
+        },
+        "N_GNN_LAYERS": {
+          "type": "integer"
+        },
+        "TRANSFORMER_D_MODEL": {
+          "type": "integer"
+        },
+        "TRANSFORMER_N_HEAD": {
+          "type": "integer"
+        },
+        "TRANSFORMER_DIM_FEEDFORWARD": {
+          "type": "integer"
+        },
+        "HEAD_N_NEURONS": {
+          "type": "integer"
+        },
+        "N_TRANS_LAYERS": {
+          "type": "integer"
+        },
+        "ACTIVATION": {
+          "type": "string"
+        },
+        "USE_LENGTH": {
+          "type": "boolean"
+        },
+        "USE_ONLY_LENGTH": {
+          "type": "boolean"
+        },
+        "R_CUT": {
+          "type": "number"
+        },
+        "R_EMBEDDING_ACTIVATION": {
+          "type": "boolean"
+        },
+        "COMPRESS_MODE": {
+          "type": "string"
+        },
+        "BLEND_NEIGHBOR_SPECIES": {
+          "type": "boolean"
+        },
+        "AVERAGE_BOND_ENERGIES": {
+          "type": "boolean"
+        },
+        "USE_BOND_ENERGIES": {
+          "type": "boolean"
+        },
+        "USE_ADDITIONAL_SCALAR_ATTRIBUTES": {
+          "type": "boolean"
+        },
+        "SCALAR_ATTRIBUTES_SIZE": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "TRANSFORMER_TYPE": {
+          "type": "string"
+        },
+        "USE_LONG_RANGE": {
+          "type": "boolean"
+        },
+        "K_CUT": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "RESIDUAL_FACTOR": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "training": {
+      "type": "object",
+      "properties": {
+        "INITIAL_LR": {
+          "type": "number"
+        },
+        "EPOCH_NUM_ATOMIC": {
+          "type": "integer"
+        },
+        "SCHEDULER_STEP_SIZE_ATOMIC": {
+          "type": "integer"
+        },
+        "EPOCHS_WARMUP_ATOMIC": {
+          "type": "integer"
+        },
+        "GLOBAL_AUG": {
+          "type": "boolean"
+        },
+        "SLIDING_FACTOR": {
+          "type": "number"
+        },
+        "ATOMIC_BATCH_SIZE": {
+          "type": "integer"
+        },
+        "MAX_TIME": {
+          "type": "integer"
+        },
+        "ENERGY_WEIGHT": {
+          "type": "number"
+        },
+        "MULTI_GPU": {
+          "type": "boolean"
+        },
+        "RANDOM_SEED": {
+          "type": "integer"
+        },
+        "CUDA_DETERMINISTIC": {
+          "type": "boolean"
+        },
+        "MODEL_TO_START_WITH": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "SUPPORT_MISSING_VALUES": {
+          "type": "boolean"
+        },
+        "USE_WEIGHT_DECAY": {
+          "type": "boolean"
+        },
+        "WEIGHT_DECAY": {
+          "type": "number"
+        },
+        "DO_GRADIENT_CLIPPING": {
+          "type": "boolean"
+        },
+        "GRADIENT_CLIPPING_MAX_NORM": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "USE_SHIFT_AGNOSTIC_LOSS": {
+          "type": "boolean"
+        },
+        "ENERGIES_LOSS": {
+          "type": "string",
+          "enum": ["per_structure", "per_atom"]
+        },
+        "BALANCED_DATA_LOADER": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
@@ -1,3 +1,5 @@
+name: experimental.soap_bpnn
+
 model:
   soap:
     cutoff: 5.0

--- a/src/metatrain/experimental/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/experimental/soap_bpnn/schema-hypers.json
@@ -1,0 +1,152 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "enum": ["experimental.soap_bpnn"]
+          },
+        "model": {
+            "type": "object",
+            "properties": {
+                "soap": {
+                    "type": "object",
+                    "properties": {
+                        "cutoff": {
+                            "type": "number"
+                        },
+                        "max_radial": {
+                            "type": "integer"
+                        },
+                        "max_angular": {
+                            "type": "integer"
+                        },
+                        "atomic_gaussian_width": {
+                            "type": "number"
+                        },
+                        "center_atom_weight": {
+                            "type": "number"
+                        },
+                        "cutoff_function": {
+                            "type": "object",
+                            "properties": {
+                                "ShiftedCosine": {
+                                    "type": "object",
+                                    "properties": {
+                                        "width": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "radial_scaling": {
+                            "type": "object",
+                            "properties": {
+                                "Willatt2018": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rate": {
+                                            "type": "number"
+                                        },
+                                        "scale": {
+                                            "type": "number"
+                                        },
+                                        "exponent": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "bpnn": {
+                    "type": "object",
+                    "properties": {
+                        "layernorm": {
+                            "type": "boolean"
+                        },
+                        "num_hidden_layers": {
+                            "type": "integer"
+                        },
+                        "num_neurons_per_layer": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "training": {
+            "type": "object",
+            "properties": {
+                "distributed": {
+                    "type": "boolean"
+                },
+                "distributed_port": {
+                    "type": "integer"
+                },
+                "batch_size": {
+                    "type": "integer"
+                },
+                "num_epochs": {
+                    "type": "integer"
+                },
+                "learning_rate": {
+                    "type": "number"
+                },
+                "early_stopping_patience": {
+                    "type": "integer"
+                },
+                "scheduler_patience": {
+                    "type": "integer"
+                },
+                "scheduler_factor": {
+                    "type": "number"
+                },
+                "log_interval": {
+                    "type": "integer"
+                },
+                "checkpoint_interval": {
+                    "type": "integer"
+                },
+                "fixed_composition_weights": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[0-9]+$": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "per_structure_targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "loss_weights": {
+                    "type": "object",
+                    "properties": {
+                        "energy": {
+                            "type": "number"
+                        },
+                        "forces": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/metatrain/experimental/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/experimental/soap_bpnn/schema-hypers.json
@@ -1,152 +1,152 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "enum": ["experimental.soap_bpnn"]
-          },
-        "model": {
-            "type": "object",
-            "properties": {
-                "soap": {
-                    "type": "object",
-                    "properties": {
-                        "cutoff": {
-                            "type": "number"
-                        },
-                        "max_radial": {
-                            "type": "integer"
-                        },
-                        "max_angular": {
-                            "type": "integer"
-                        },
-                        "atomic_gaussian_width": {
-                            "type": "number"
-                        },
-                        "center_atom_weight": {
-                            "type": "number"
-                        },
-                        "cutoff_function": {
-                            "type": "object",
-                            "properties": {
-                                "ShiftedCosine": {
-                                    "type": "object",
-                                    "properties": {
-                                        "width": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "radial_scaling": {
-                            "type": "object",
-                            "properties": {
-                                "Willatt2018": {
-                                    "type": "object",
-                                    "properties": {
-                                        "rate": {
-                                            "type": "number"
-                                        },
-                                        "scale": {
-                                            "type": "number"
-                                        },
-                                        "exponent": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "bpnn": {
-                    "type": "object",
-                    "properties": {
-                        "layernorm": {
-                            "type": "boolean"
-                        },
-                        "num_hidden_layers": {
-                            "type": "integer"
-                        },
-                        "num_neurons_per_layer": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        },
-        "training": {
-            "type": "object",
-            "properties": {
-                "distributed": {
-                    "type": "boolean"
-                },
-                "distributed_port": {
-                    "type": "integer"
-                },
-                "batch_size": {
-                    "type": "integer"
-                },
-                "num_epochs": {
-                    "type": "integer"
-                },
-                "learning_rate": {
-                    "type": "number"
-                },
-                "early_stopping_patience": {
-                    "type": "integer"
-                },
-                "scheduler_patience": {
-                    "type": "integer"
-                },
-                "scheduler_factor": {
-                    "type": "number"
-                },
-                "log_interval": {
-                    "type": "integer"
-                },
-                "checkpoint_interval": {
-                    "type": "integer"
-                },
-                "fixed_composition_weights": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^[0-9]+$": {
-                            "type": "number"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "per_structure_targets": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "loss_weights": {
-                    "type": "object",
-                    "properties": {
-                        "energy": {
-                            "type": "number"
-                        },
-                        "forces": {
-                            "type": "number"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["experimental.soap_bpnn"]
     },
-    "additionalProperties": false
+    "model": {
+      "type": "object",
+      "properties": {
+        "soap": {
+          "type": "object",
+          "properties": {
+            "cutoff": {
+              "type": "number"
+            },
+            "max_radial": {
+              "type": "integer"
+            },
+            "max_angular": {
+              "type": "integer"
+            },
+            "atomic_gaussian_width": {
+              "type": "number"
+            },
+            "center_atom_weight": {
+              "type": "number"
+            },
+            "cutoff_function": {
+              "type": "object",
+              "properties": {
+                "ShiftedCosine": {
+                  "type": "object",
+                  "properties": {
+                    "width": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "radial_scaling": {
+              "type": "object",
+              "properties": {
+                "Willatt2018": {
+                  "type": "object",
+                  "properties": {
+                    "rate": {
+                      "type": "number"
+                    },
+                    "scale": {
+                      "type": "number"
+                    },
+                    "exponent": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "bpnn": {
+          "type": "object",
+          "properties": {
+            "layernorm": {
+              "type": "boolean"
+            },
+            "num_hidden_layers": {
+              "type": "integer"
+            },
+            "num_neurons_per_layer": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "training": {
+      "type": "object",
+      "properties": {
+        "distributed": {
+          "type": "boolean"
+        },
+        "distributed_port": {
+          "type": "integer"
+        },
+        "batch_size": {
+          "type": "integer"
+        },
+        "num_epochs": {
+          "type": "integer"
+        },
+        "learning_rate": {
+          "type": "number"
+        },
+        "early_stopping_patience": {
+          "type": "integer"
+        },
+        "scheduler_patience": {
+          "type": "integer"
+        },
+        "scheduler_factor": {
+          "type": "number"
+        },
+        "log_interval": {
+          "type": "integer"
+        },
+        "checkpoint_interval": {
+          "type": "integer"
+        },
+        "fixed_composition_weights": {
+          "type": "object",
+          "patternProperties": {
+            "^[0-9]+$": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "per_structure_targets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "loss_weights": {
+          "type": "object",
+          "properties": {
+            "energy": {
+              "type": "number"
+            },
+            "forces": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/metatrain/share/schema-base.json
+++ b/src/metatrain/share/schema-base.json
@@ -1,0 +1,106 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "dataset_object": {
+            "type": "object",
+            "additionalProperties": true
+        },
+        "dataset_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": true
+            }
+        },
+        "dataset_string": {
+            "type": "string",
+            "format": "uri"
+        }
+    },
+    "type": "object",
+    "properties": {
+        "device": {
+            "type": "string"
+        },
+        "base_precision": {
+            "type": "integer",
+            "enum": [
+                16,
+                32,
+                64
+            ]
+        },
+        "seed": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "architecture": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": true
+        },
+        "training_set": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/dataset_object"
+                },
+                {
+                    "$ref": "#/$defs/dataset_array"
+                },
+                {
+                    "$ref": "#/$defs/dataset_string"
+                }
+            ]
+        },
+        "test_set": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/dataset_object"
+                },
+                {
+                    "$ref": "#/$defs/dataset_array"
+                },
+                {
+                    "$ref": "#/$defs/dataset_string"
+                },
+                {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMaximum": 1
+                }
+            ]
+        },
+        "validation_set": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/dataset_object"
+                },
+                {
+                    "$ref": "#/$defs/dataset_array"
+                },
+                {
+                    "$ref": "#/$defs/dataset_string"
+                },
+                {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1
+                }
+            ]
+        }
+    },
+    "required": [
+        "architecture",
+        "training_set",
+        "test_set",
+        "validation_set"
+    ],
+    "additionalProperties": false
+}

--- a/src/metatrain/share/schema-base.json
+++ b/src/metatrain/share/schema-base.json
@@ -1,106 +1,95 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$defs": {
-        "dataset_object": {
-            "type": "object",
-            "additionalProperties": true
-        },
-        "dataset_array": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": true
-            }
-        },
-        "dataset_string": {
-            "type": "string",
-            "format": "uri"
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "dataset_object": {
+      "type": "object",
+      "additionalProperties": true
     },
-    "type": "object",
-    "properties": {
-        "device": {
-            "type": "string"
-        },
-        "base_precision": {
-            "type": "integer",
-            "enum": [
-                16,
-                32,
-                64
-            ]
-        },
-        "seed": {
-            "type": "integer",
-            "minimum": 0
-        },
-        "architecture": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "additionalProperties": true
-        },
-        "training_set": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/dataset_object"
-                },
-                {
-                    "$ref": "#/$defs/dataset_array"
-                },
-                {
-                    "$ref": "#/$defs/dataset_string"
-                }
-            ]
-        },
-        "test_set": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/dataset_object"
-                },
-                {
-                    "$ref": "#/$defs/dataset_array"
-                },
-                {
-                    "$ref": "#/$defs/dataset_string"
-                },
-                {
-                    "type": "number",
-                    "minimum": 0,
-                    "exclusiveMaximum": 1
-                }
-            ]
-        },
-        "validation_set": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/dataset_object"
-                },
-                {
-                    "$ref": "#/$defs/dataset_array"
-                },
-                {
-                    "$ref": "#/$defs/dataset_string"
-                },
-                {
-                    "type": "number",
-                    "exclusiveMinimum": 0,
-                    "exclusiveMaximum": 1
-                }
-            ]
-        }
+    "dataset_array": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
     },
-    "required": [
-        "architecture",
-        "training_set",
-        "test_set",
-        "validation_set"
-    ],
-    "additionalProperties": false
+    "dataset_string": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "device": {
+      "type": "string"
+    },
+    "base_precision": {
+      "type": "integer",
+      "enum": [16, 32, 64]
+    },
+    "seed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "architecture": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "training_set": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/dataset_object"
+        },
+        {
+          "$ref": "#/$defs/dataset_array"
+        },
+        {
+          "$ref": "#/$defs/dataset_string"
+        }
+      ]
+    },
+    "test_set": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/dataset_object"
+        },
+        {
+          "$ref": "#/$defs/dataset_array"
+        },
+        {
+          "$ref": "#/$defs/dataset_string"
+        },
+        {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 1
+        }
+      ]
+    },
+    "validation_set": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/dataset_object"
+        },
+        {
+          "$ref": "#/$defs/dataset_array"
+        },
+        {
+          "$ref": "#/$defs/dataset_string"
+        },
+        {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1
+        }
+      ]
+    }
+  },
+  "required": ["architecture", "training_set", "test_set", "validation_set"],
+  "additionalProperties": false
 }

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -1,147 +1,147 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$defs": {
-        "read_from": {
-            "type": "string",
-            "format": "uri"
-        },
-        "file_format": {
-            "type": "string"
-        },
-        "gradient_section": {
-            "oneOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "$ref": "#/$defs/read_from"
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "read_from": {
-                            "$ref": "#/$defs/read_from"
-                        },
-                        "file_format": {
-                            "$ref": "#/$defs/file_format"
-                        },
-                        "key": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        },
-        "dataset_section": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": true
-                    }
-                },
-                {
-                    "type": "string",
-                    "format": "uri"
-                }
-            ]
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "read_from": {
+      "type": "string",
+      "format": "uri"
     },
-    "type": "object",
-    "properties": {
-        "systems": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/read_from"
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "read_from": {
-                            "$ref": "#/$defs/read_from"
-                        },
-                        "file_format": {
-                            "$ref": "#/$defs/file_format"
-                        },
-                        "length_unit": {
-                            "oneOf": [
-                                {
-                                    "type": "null"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
+    "file_format": {
+      "type": "string"
+    },
+    "gradient_section": {
+      "oneOf": [
+        {
+          "type": "boolean"
         },
-        "targets": {
-            "type": "object",
-            "patternProperties": {
-                ".*": {
-                    "oneOf": [
-                        {
-                            "$ref": "#/$defs/read_from"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "quantity": {
-                                    "type": "string"
-                                },
-                                "read_from": {
-                                    "$ref": "#/$defs/read_from"
-                                },
-                                "file_format": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/$defs/file_format"
-                                        },
-                                        {
-                                            "type": "object",
-                                            "additionalProperties": true
-                                        }
-                                    ]
-                                },
-                                "key": {
-                                    "type": "string"
-                                },
-                                "unit": {
-                                    "oneOf": [
-                                        {
-                                            "type": "null"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "forces": {
-                                    "$ref": "#/$defs/gradient_section"
-                                },
-                                "stress": {
-                                    "$ref": "#/$defs/gradient_section"
-                                },
-                                "virial": {
-                                    "$ref": "#/$defs/gradient_section"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    ]
-                }
+        {
+          "$ref": "#/$defs/read_from"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "read_from": {
+              "$ref": "#/$defs/read_from"
             },
-            "additionalProperties": false
+            "file_format": {
+              "$ref": "#/$defs/file_format"
+            },
+            "key": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
+      ]
     },
-    "additionalProperties": false
+    "dataset_section": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": true
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "systems": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/read_from"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "read_from": {
+              "$ref": "#/$defs/read_from"
+            },
+            "file_format": {
+              "$ref": "#/$defs/file_format"
+            },
+            "length_unit": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "targets": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/read_from"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "quantity": {
+                  "type": "string"
+                },
+                "read_from": {
+                  "$ref": "#/$defs/read_from"
+                },
+                "file_format": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/$defs/file_format"
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  ]
+                },
+                "key": {
+                  "type": "string"
+                },
+                "unit": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "forces": {
+                  "$ref": "#/$defs/gradient_section"
+                },
+                "stress": {
+                  "$ref": "#/$defs/gradient_section"
+                },
+                "virial": {
+                  "$ref": "#/$defs/gradient_section"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -1,0 +1,147 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "read_from": {
+            "type": "string",
+            "format": "uri"
+        },
+        "file_format": {
+            "type": "string"
+        },
+        "gradient_section": {
+            "oneOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "$ref": "#/$defs/read_from"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "read_from": {
+                            "$ref": "#/$defs/read_from"
+                        },
+                        "file_format": {
+                            "$ref": "#/$defs/file_format"
+                        },
+                        "key": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "dataset_section": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                {
+                    "type": "string",
+                    "format": "uri"
+                }
+            ]
+        }
+    },
+    "type": "object",
+    "properties": {
+        "systems": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/read_from"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "read_from": {
+                            "$ref": "#/$defs/read_from"
+                        },
+                        "file_format": {
+                            "$ref": "#/$defs/file_format"
+                        },
+                        "length_unit": {
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "targets": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/read_from"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "quantity": {
+                                    "type": "string"
+                                },
+                                "read_from": {
+                                    "$ref": "#/$defs/read_from"
+                                },
+                                "file_format": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/file_format"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    ]
+                                },
+                                "key": {
+                                    "type": "string"
+                                },
+                                "unit": {
+                                    "oneOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "forces": {
+                                    "$ref": "#/$defs/gradient_section"
+                                },
+                                "stress": {
+                                    "$ref": "#/$defs/gradient_section"
+                                },
+                                "virial": {
+                                    "$ref": "#/$defs/gradient_section"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/metatrain/utils/architectures.py
+++ b/src/metatrain/utils/architectures.py
@@ -1,8 +1,10 @@
 import difflib
+import json
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Dict, List, Union
 
+from jsonschema import validate
 from omegaconf import OmegaConf
 
 from .. import PACKAGE_ROOT
@@ -48,6 +50,26 @@ def check_architecture_name(name: str) -> None:
         )
 
     raise ValueError(msg)
+
+
+def check_architecture_options(
+    name: str,
+    options: Dict,
+) -> None:
+    """Verifies that an options instance only contains valid keys
+
+    If the architecture developer does not provide a validation scheme the ``options``
+    will not checked.
+
+    :param name: name of the architecture
+    :param options: architecture options to check
+    """
+    schema_path = get_architecture_path(name) / "schema-hypers.json"
+    if schema_path.exists():
+        with open(schema_path, "r") as f:
+            schema = json.load(f)
+
+        validate(instance=options, schema=schema)
 
 
 def get_architecture_name(path: Union[str, Path]) -> str:

--- a/src/metatrain/utils/architectures.py
+++ b/src/metatrain/utils/architectures.py
@@ -1,5 +1,6 @@
 import difflib
 import json
+import logging
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Dict, List, Union
@@ -70,6 +71,8 @@ def check_architecture_options(
             schema = json.load(f)
 
         validate(instance=options, schema=schema)
+    else:
+        logging.debug("No schema found for {name!r} architecture. Skipping validation.")
 
 
 def get_architecture_name(path: Union[str, Path]) -> str:

--- a/src/metatrain/utils/omegaconf.py
+++ b/src/metatrain/utils/omegaconf.py
@@ -1,12 +1,14 @@
 import importlib
+import json
 from pathlib import Path
 from typing import Any, Union
 
 import torch
+from jsonschema import validate
 from omegaconf import Container, DictConfig, ListConfig, OmegaConf
 from omegaconf.basecontainer import BaseContainer
 
-from .. import RANDOM_SEED
+from .. import PACKAGE_ROOT, RANDOM_SEED
 from .devices import pick_devices
 
 
@@ -80,7 +82,7 @@ def _resolve_single_str(config: str) -> DictConfig:
     return OmegaConf.create({"read_from": config})
 
 
-# BASE CONFIGURATIONS
+# Base options/configurations
 BASE_OPTIONS = OmegaConf.create(
     {
         "device": "${default_device:}",
@@ -119,11 +121,73 @@ CONF_GRADIENT = OmegaConf.create(
 
 KNWON_GRADIENTS = list(CONF_GRADIENTS.keys())
 
-# merge configs to get default configs for energies and other targets
+# Merge configs to get default configs for energies and other targets
 CONF_TARGET = OmegaConf.merge(CONF_TARGET_FIELDS, CONF_GRADIENTS)
 CONF_ENERGY = CONF_TARGET.copy()
 CONF_ENERGY["forces"] = CONF_GRADIENT.copy()
 CONF_ENERGY["stress"] = CONF_GRADIENT.copy()
+
+# Schema with the dataset options
+with open(PACKAGE_ROOT / "share/schema-dataset.json") as f:
+    SCHEMA_DATASET = json.load(f)
+
+
+def check_dataset_options(dataset_config: ListConfig) -> None:
+    """Perform consistency checks within one dataset config.
+
+    This is useful if the dataset config is made of several datasets.
+
+    - The function checks if ``length_units`` in each system section are known and the
+       same.
+    - For unknown quantities a warning is given.
+    - If the names of the ``"targets"`` sections are the same between the elements of
+       the list of datasets also the units must be the same.
+
+    :param dataset_config: A List of configuration to be checked. In the list contains
+        only one element no checks are performed.
+    :raises ValueError: If for a known quantity the units are not known.
+    """
+    desired_config = dataset_config[0]
+
+    if hasattr(desired_config, "targets"):
+        # save unit for each target seaction for later comparison
+        unit_dict = {k: v["unit"] for k, v in desired_config["targets"].items()}
+    else:
+        unit_dict = {}
+
+    if hasattr(desired_config, "systems"):
+        desired_length_unit = desired_config["systems"]["length_unit"]
+    else:
+        desired_length_unit = None
+
+    # loop over ALL configs because we have check units for all elements in
+    # `dataset_config`
+    for actual_config in dataset_config:
+        if desired_length_unit:
+            # Perform consistency checks between config elements
+            actual_length_unit = actual_config["systems"]["length_unit"]
+            if actual_length_unit != desired_length_unit:
+                raise ValueError(
+                    "`length_unit`s are inconsistent between one of the dataset "
+                    f"options. {actual_length_unit!r} != {desired_length_unit!r}."
+                )
+
+        if hasattr(actual_config, "targets"):
+            for target_key, target in actual_config["targets"].items():
+                unit = target["unit"]
+
+                # If a target section name is not part of the saved units we add it for
+                # later comparison. We do not have to start the loop again because this
+                # target section name is not present in one of the datasets checked
+                # before.
+                if target_key not in unit_dict.keys():
+                    unit_dict[target_key] = unit
+
+                if unit_dict[target_key] != unit:
+                    raise ValueError(
+                        f"Units of target section {target_key!r} are inconsistent. "
+                        f"Found {unit!r} and {unit_dict[target_key]!r}!"
+                    )
 
 
 def expand_dataset_config(conf: Union[str, DictConfig, ListConfig]) -> ListConfig:
@@ -168,6 +232,7 @@ def expand_dataset_config(conf: Union[str, DictConfig, ListConfig]) -> ListConfi
 
     # Perform expansion per config inside the ListConfig
     for conf_element in conf:
+        validate(instance=OmegaConf.to_container(conf_element), schema=SCHEMA_DATASET)
         if hasattr(conf_element, "systems"):
             if type(conf_element["systems"]) is str:
                 conf_element["systems"] = _resolve_single_str(conf_element["systems"])
@@ -240,6 +305,7 @@ def expand_dataset_config(conf: Union[str, DictConfig, ListConfig]) -> ListConfi
                         "`stress: off`."
                     )
 
+    check_dataset_options(conf)
     return conf
 
 
@@ -296,52 +362,4 @@ def check_units(
                 raise ValueError(
                     f"Target {target!r} is not present in one of the given dataset "
                     "options."
-                )
-
-
-def check_options_list(dataset_config: ListConfig) -> None:
-    """Perform consistency checks within one dataset config.
-
-    This is useful if the dataset config is made of several datasets.
-
-    - The function checks if ``length_units`` in each system section are known and the
-       same.
-    - For unknown quantities a warning is given.
-    - If the names of the ``"targets"`` sections are the same between the elements of
-       the list of datasets also the units must be the same.
-
-    :param dataset_config: A List of configuration to be checked. In the list contains
-        only one element no checks are performed.
-    :raises ValueError: If for a known quantity the units are not known.
-    """
-    desired_config = dataset_config[0]
-    # save unit for each target seaction for later comparison
-    unit_dict = {k: v["unit"] for k, v in desired_config["targets"].items()}
-
-    desired_length_unit = desired_config["systems"]["length_unit"]
-
-    # loop over ALL configs because we have check units for all elements in
-    # `dataset_config`
-    for actual_config in dataset_config:
-        # Perform consistency checks between config elements
-        actual_length_unit = actual_config["systems"]["length_unit"]
-        if actual_length_unit != desired_length_unit:
-            raise ValueError(
-                "`length_unit`s are inconsistent between one of the dataset options."
-                f" {actual_length_unit!r} != {desired_length_unit!r}."
-            )
-
-        for target_key, target in actual_config["targets"].items():
-            unit = target["unit"]
-
-            # If a target section name is not part of the saved units we add it for
-            # later comparison. We do not have to start the loop again because this
-            # target section name is not present in one of the datasets checked before.
-            if target_key not in unit_dict.keys():
-                unit_dict[target_key] = unit
-
-            if unit_dict[target_key] != unit:
-                raise ValueError(
-                    f"Units of target section {target_key!r} are inconsistent. Found "
-                    f"{unit!r} and {unit_dict[target_key]!r}!"
                 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -134,7 +134,6 @@ def test_error(subcommand, capfd, monkeypatch, tmp_path):
     with open(error_file) as f:
         error_log = f.read()
 
-    print(error_file)
     assert f"please include the full traceback log from {error_file!r}" in stdout_log
     assert "No such file or directory" in stdout_log
     assert "Traceback" in error_log

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -299,6 +299,7 @@ def test_empty_test_set(caplog, monkeypatch, tmp_path, options):
     # check if the logging is correct
     assert "This dataset is empty. No evaluation" in caplog.text
 
+
 @pytest.mark.parametrize(
     "test_set_file, validation_set_file", [(True, False), (False, True)]
 )

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -9,8 +9,10 @@ import ase.io
 import metatensor.torch  # noqa
 import pytest
 import torch
+from jsonschema.exceptions import ValidationError
 from omegaconf import OmegaConf
 
+from metatrain import RANDOM_SEED
 from metatrain.cli.train import train_model
 from metatrain.utils.errors import ArchitectureError
 
@@ -113,6 +115,49 @@ def test_command_line_override(monkeypatch, tmp_path, overrides):
         assert restart_options["architecture"]["training"]["batch_size"] == 3
 
 
+def test_train_from_options_restart_yaml(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
+
+    # run training with original options
+    options = OmegaConf.load(OPTIONS_PATH)
+    train_model(options)
+
+    # run training with options_restart.yaml
+    options_restart = OmegaConf.load("options_restart.yaml")
+    train_model(options_restart)
+
+
+def test_train_unknonw_arch_options(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
+
+    options_str = """
+    architecture:
+        name: experimental.soap_bpnn
+        training:
+            batch_size: 2
+            num_epoch: 1
+
+    training_set:
+        systems:
+            read_from: qm9_reduced_100.xyz
+            length_unit: angstrom
+        targets:
+            energy:
+            key: U0
+            unit: eV
+
+    test_set: 0.5
+    validation_set: 0.1
+    """
+    options = OmegaConf.create(options_str)
+
+    match = r"Additional properties are not allowed \('num_epoch' was unexpected\)"
+    with pytest.raises(ValidationError, match=match):
+        train_model(options)
+
+
 @pytest.mark.parametrize("n_datasets", [1, 2])
 @pytest.mark.parametrize("test_set_file", (True, False))
 @pytest.mark.parametrize("validation_set_file", (True, False))
@@ -211,8 +256,12 @@ def test_wrong_test_split_size(split, monkeypatch, tmp_path, options):
     options["validation_set"] = 0.1
     options["test_set"] = split
 
-    match = r"Test set split must be greater or equal than 0 and lesser than 1."
-    with pytest.raises(ValueError, match=match):
+    if split > 1:
+        match = rf"{split} is greater than or equal to the maximum of 1"
+    if split < 0:
+        match = rf"{split} is less than the minimum of 0"
+
+    with pytest.raises(ValidationError, match=match):
         train_model(options)
 
 
@@ -226,13 +275,17 @@ def test_wrong_validation_split_size(split, monkeypatch, tmp_path, options):
     options["validation_set"] = split
     options["test_set"] = 0.1
 
-    match = r"Validation set split must be greater than 0 and lesser than 1."
-    with pytest.raises(ValueError, match=match):
+    if split > 1:
+        match = rf"{split} is greater than or equal to the maximum of 1"
+    if split <= 0:
+        match = rf"{split} is less than or equal to the minimum of 0"
+
+    with pytest.raises(ValidationError, match=match):
         train_model(options)
 
 
 def test_empty_test_set(caplog, monkeypatch, tmp_path, options):
-    """Test that no error is raised if no test set is provided."""
+    """Test that NO error is raised if no test set is provided."""
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.DEBUG)
 
@@ -245,7 +298,6 @@ def test_empty_test_set(caplog, monkeypatch, tmp_path, options):
 
     # check if the logging is correct
     assert "This dataset is empty. No evaluation" in caplog.text
-
 
 @pytest.mark.parametrize(
     "test_set_file, validation_set_file", [(True, False), (False, True)]
@@ -307,7 +359,7 @@ def test_inconsistent_number_of_datasets(
         options["test_set"]["systems"]["read_from"] = "test.xyz"
         options["test_set"] = OmegaConf.create(2 * [options["test_set"]])
 
-    with pytest.raises(ValueError, match="different size than the train datatset"):
+    with pytest.raises(ValueError, match="different size than the training datatset"):
         train_model(options)
 
 
@@ -367,59 +419,43 @@ def test_continue_different_dataset(options, monkeypatch, tmp_path):
     train_model(options, continue_from=MODEL_PATH_64_BIT)
 
 
-def test_no_architecture_name(options):
-    """Test error raise if architecture.name is not set."""
-    options["architecture"].pop("name")
-
-    with pytest.raises(ValueError, match="Architecture name is not defined!"):
-        train_model(options)
-
-
-@pytest.mark.parametrize("seed", [1234, 0, -123])
-@pytest.mark.parametrize("architecture_name", ["experimental.soap_bpnn"])
-def test_model_consistency_with_seed(
-    options, monkeypatch, tmp_path, architecture_name, seed
-):
+@pytest.mark.parametrize("seed", [None, 1234])
+def test_model_consistency_with_seed(options, monkeypatch, tmp_path, seed):
     """Checks final model consistency with a fixed seed."""
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
 
-    options["architecture"]["name"] = architecture_name
-    options["seed"] = seed
-
-    if seed is not None and seed < 0:
-        with pytest.raises(ValueError, match="`seed` should be a positive number"):
-            train_model(options)
-        return
+    if seed is not None:
+        options["seed"] = seed
 
     train_model(options, output="model1.pt")
+
+    if seed is None:
+        options["seed"] = RANDOM_SEED + 1
+
     train_model(options, output="model2.pt")
 
     m1 = torch.load("model1.ckpt")
     m2 = torch.load("model2.ckpt")
 
-    for index, i in enumerate(m1["model_state_dict"]):
+    for i in m1["model_state_dict"]:
         tensor1 = m1["model_state_dict"][i]
         tensor2 = m2["model_state_dict"][i]
 
-        # The first tensor only depend on the chemical compositions (not on the
-        # seed) and should alwyas be the same.
-        if index == 0:
-            torch.testing.assert_close(tensor1, tensor2)
+        if seed is None:
+            assert not torch.allclose(tensor1, tensor2)
         else:
-            if seed is None:
-                assert not torch.allclose(tensor1, tensor2)
-            else:
-                torch.testing.assert_close(tensor1, tensor2)
+            torch.testing.assert_close(tensor1, tensor2)
 
 
-def test_error_base_precision(options, monkeypatch, tmp_path):
-    """Test unsupported `base_precision`"""
+def test_base_validation(options, monkeypatch, tmp_path):
+    """Test that the base options are validated."""
     monkeypatch.chdir(tmp_path)
 
-    options["base_precision"] = "123"
+    options["base_precision"] = 67
 
-    with pytest.raises(ValueError, match="Only 64, 32 or 16 are possible values for"):
+    match = r"67 is not one of \[16, 32, 64\]"
+    with pytest.raises(ValidationError, match=match):
         train_model(options)
 
 
@@ -433,22 +469,12 @@ def test_different_base_precision(options, monkeypatch, tmp_path, base_precision
     train_model(options)
 
 
-def test_unsupported_dtype(options):
-    options["base_precision"] = 16
-    match = (
-        r"Requested dtype torch.float16 is not supported. experimental.soap_bpnn "
-        r"only supports \[torch.float64, torch.float32\]."
-    )
-    with pytest.raises(ValueError, match=match):
-        train_model(options)
-
-
 def test_architecture_error(options, monkeypatch, tmp_path):
     """Test an error raise if there is problem wth the architecture."""
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
 
-    options["architecture"]["model"] = OmegaConf.create({"soap": {"cutoff": -1}})
+    options["architecture"]["model"] = OmegaConf.create({"soap": {"cutoff": -1.0}})
 
     with pytest.raises(ArchitectureError, match="originates from an architecture"):
         train_model(options)

--- a/tox.ini
+++ b/tox.ini
@@ -141,10 +141,11 @@ allowlist_externals =
 extras = # these models are used in the documentation
     gap
     soap-bpnn
-commands =
+commands_pre =
     # Run example and usage scripts.
     bash -c "set -e && cd {toxinidir}/examples/basic_usage && bash usage.sh"
     bash -c "set -e && cd {toxinidir}/examples/ase && bash train.sh"
+commands =
     sphinx-build \
         {posargs:-E} \
         --builder html \


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Partly closes #168 since for now I only added a verification for the architecture hypers using a function `check_architecture_options`. For the checking the dataset it is a bit more complicated because the yaml layout is very flexible. I think it is doable but also to keep the PR a bit smaller I will do this in another run.

While touching the code I also moved the `check_options_list` inside the dataset expansion because these two functions always will be called together. Also, there was no test if the written `option_restart.yaml` is actually a valid input to start another training run.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--241.org.readthedocs.build/en/241/

<!-- readthedocs-preview metatrain end -->