### PR TITLE
Distributing tests across multiple CPUs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -97,44 +97,40 @@ description = Run SOAP-BPNN tests with pytest
 passenv = *
 deps =
     pytest
-    pytest-xdist
 extras = soap-bpnn
 changedir = src/metatrain/experimental/soap_bpnn/tests/
 commands =
-    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:alchemical-model-tests]
 description = Run Alchemical Model tests with pytest
 passenv = *
 deps =
     pytest
-    pytest-xdist
 extras = alchemical-model
 changedir = src/metatrain/experimental/alchemical_model/tests/
 commands =
-    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:pet-tests]
 description = Run PET tests with pytest
 passenv = *
 deps =
     pytest
-    pytest-xdist
 extras = pet
 changedir = src/metatrain/experimental/pet/tests/
 commands =
-    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:gap-tests]
 description = Run GAP tests with pytest
 passenv = *
 deps =
     pytest
-    pytest-xdist
 extras = gap
 changedir = src/metatrain/experimental/gap/tests/
 commands =
-    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:docs]
 description = builds the documentation with sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -61,12 +61,14 @@ passenv = *
 deps =
     pytest
     pytest-cov
+    pytest-xdist
 changedir = tests
 extras = soap-bpnn  # this model is used in the package tests
 allowlist_externals = bash
 commands_pre = bash {toxinidir}/tests/resources/generate-outputs.sh
 commands =
     pytest \
+        --numprocesses=auto \
         --cov={env_site_packages_dir}/metatrain \
         --cov-append \
         --cov-report= \
@@ -95,40 +97,44 @@ description = Run SOAP-BPNN tests with pytest
 passenv = *
 deps =
     pytest
+    pytest-xdist
 extras = soap-bpnn
 changedir = src/metatrain/experimental/soap_bpnn/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
 
 [testenv:alchemical-model-tests]
 description = Run Alchemical Model tests with pytest
 passenv = *
 deps =
     pytest
+    pytest-xdist
 extras = alchemical-model
 changedir = src/metatrain/experimental/alchemical_model/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
 
 [testenv:pet-tests]
 description = Run PET tests with pytest
 passenv = *
 deps =
     pytest
+    pytest-xdist
 extras = pet
 changedir = src/metatrain/experimental/pet/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
 
 [testenv:gap-tests]
 description = Run GAP tests with pytest
 passenv = *
 deps =
     pytest
+    pytest-xdist
 extras = gap
 changedir = src/metatrain/experimental/gap/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest --numprocesses=auto {[testenv]warning_options} {posargs}
 
 [testenv:docs]
 description = builds the documentation with sphinx


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Using [pytest-xdist](https://pypi.org/project/pytest-xdist/) and parallization of the data generation to speed up tests (a little). They are still very slow which basically originates from the training several BPNNs in the tests. We should tackle this soon because running the whole test suite is really annoying. Most of the time currently goes into these tests:

```
34.89s call     tests/cli/test_train_model.py::test_command_line_override[architecture.training.num_epochs=2 architecture.training.batch_size=3]
31.17s call     tests/cli/test_train_model.py::test_empty_test_set
29.64s call     tests/cli/test_train_model.py::test_train[None]
26.82s call     tests/cli/test_train_model.py::test_continue
24.43s call     tests/cli/test_train_model.py::test_train_explicit_validation_test[True-True-2]
24.09s call     tests/cli/test_train_model.py::test_model_consistency_with_seed[experimental.soap_bpnn-1234]
22.73s call     tests/cli/test_train_model.py::test_train_explicit_validation_test[False-False-2]
21.52s call     tests/cli/test_train_model.py::test_continue_different_dataset
20.98s call     tests/cli/test_train_model.py::test_train_explicit_validation_test[True-True-1]
20.32s call     tests/cli/test_train_model.py::test_train_multiple_datasets
```

I found the following timings on my machine with an Apple M2

## single thread
first run: _6m32.412s_
second run: _4m11.565s_

## threaded 8threads
first run: _3m38.036s_
second run: _2m15.751s_ 

which is a speedup by a **factor of 2**. 

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview metatrain end -->