### PR TITLE
Rename `disp` to `strain`

### DIFF
--- a/src/metatrain/utils/evaluate_model.py
+++ b/src/metatrain/utils/evaluate_model.py
@@ -88,10 +88,10 @@ def evaluate_model(
         target_requires_pos_gradients = (
             energy_target in energy_targets_that_require_position_gradients
         )
-        target_requires_disp_gradients = (
+        target_requires_strain_gradients = (
             energy_target in energy_targets_that_require_strain_gradients
         )
-        if target_requires_pos_gradients and target_requires_disp_gradients:
+        if target_requires_pos_gradients and target_requires_strain_gradients:
             gradients = compute_gradient(
                 model_outputs[energy_target].block().values,
                 [system.positions for system in systems] + strains,
@@ -125,7 +125,7 @@ def evaluate_model(
                 blocks=[new_block],
             )
             model_outputs[energy_target] = new_energy_tensor_map
-        elif target_requires_disp_gradients:
+        elif target_requires_strain_gradients:
             gradients = compute_gradient(
                 model_outputs[energy_target].block().values,
                 strains,

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -201,15 +201,15 @@ def test_read_targets(stress_dict, virial_dict, monkeypatch, tmp_path, caplog):
             ]
             assert pos_grad.properties == Labels("energy", torch.tensor([[0]]))
 
-            disp_grad = result_block.gradient("strain")
+            strain_grad = result_block.gradient("strain")
             components = [
                 Labels(["xyz_1"], torch.arange(3).reshape(-1, 1)),
                 Labels(["xyz_2"], torch.arange(3).reshape(-1, 1)),
             ]
-            assert disp_grad.values.dtype is torch.float16
-            assert disp_grad.samples.names == ["sample"]
-            assert disp_grad.components == components
-            assert disp_grad.properties == Labels("energy", torch.tensor([[0]]))
+            assert strain_grad.values.dtype is torch.float16
+            assert strain_grad.samples.names == ["sample"]
+            assert strain_grad.components == components
+            assert strain_grad.properties == Labels("energy", torch.tensor([[0]]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A leftover from the time when we renamed `displacement` to `strain`

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview metatrain end -->