### PR TITLE
Stop using macos-11 on CI, it is deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
             python-version: "3.9"
           - os: ubuntu-22.04
             python-version: "3.12"
-          - os: macos-11
+          - os: macos-14
             python-version: "3.12"
           # To be restored once we figure out the issue with the windows build
           # - os: windows-2019


### PR DESCRIPTION
As it says in the title!


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--270.org.readthedocs.build/en/270/

<!-- readthedocs-preview metatrain end -->