### PR TITLE
Always read files in double precision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ architecture.
 
 What is metatrain?
 ##################
-``metatrain`` is a command line interface (cli) to `train` and `evaluate` atomistic
+``metatrain`` is a command line interface (cli) to ``train`` and ``evaluate`` atomistic
 models of various architectures. It features a common ``yaml`` option inputs to
 configure training and evaluation. Trained models are exported as standalone files that
 can be used directly in various molecular dynamics (MD) engines (e.g. ``LAMMPS``,
@@ -30,7 +30,7 @@ that can be connected to an MD engine. Any custom architecture compatible with
 TorchScript_ can be integrated in ``metatrain``, gaining automatic access to a training
 and evaluation interface, as well as compatibility with various MD engines.
 
-Note: ``metatrain`` does not provide mathematical functionalities `per se` but relies on
+Note: ``metatrain`` does not provide mathematical functionalities *per se* but relies on
 external models that implement the various architectures.
 
 .. _TorchScript: https://pytorch.org/docs/stable/jit.html

--- a/docs/src/architectures/pet.rst
+++ b/docs/src/architectures/pet.rst
@@ -152,8 +152,8 @@ training dataset. All default values are given by atomic versions for better
 transferability across various datasets.
 
 To increase the step size of the learning rate scheduler by, for example, 2 times, take
-the default value for ``SCHEDULER_STEP_SIZE_ATOMIC`` from the default_hypers and specify
-a value that's twice as large.
+the default value for ``SCHEDULER_STEP_SIZE_ATOMIC`` from the default hypers and
+specify a value that's twice as large.
 
 It is worth noting that the stopping criterion of PET is either exceeding the maximum
 number of epochs (specified by ``EPOCH_NUM`` or ``EPOCH_NUM_ATOMIC``) or exceeding the
@@ -168,11 +168,11 @@ probability of achieving the best accuracy on a typical moderate-sized dataset. 
 result, some default hyperparameters might be excessive, meaning they could be adjusted
 to significantly increase the model's speed with minimal impact on accuracy. For
 practical use, especially when conducting massive calculations where model speed is
-crucial, it may be beneficial to set ``N_TRANS_LAYERS`` to `2` instead of the default
-value of `3`. The ``N_TRANS_LAYERS`` hyperparameter controls the number of transformer
+crucial, it may be beneficial to set ``N_TRANS_LAYERS`` to ``2`` instead of the default
+value of ``3``. The ``N_TRANS_LAYERS`` hyperparameter controls the number of transformer
 layers in each message-passing block (see more details in the `PET paper
 <https://arxiv.org/abs/2305.19302>`_). This adjustment would result in a model that is
-about `1.5` times more lightweight and faster, with an expected minimal deterioration in
+about *1.5 times* more lightweight and faster, with an expected minimal deterioration in
 accuracy.
 
 Architecture Hyperparameters

--- a/docs/src/dev-docs/architecture-life-cycle.rst
+++ b/docs/src/dev-docs/architecture-life-cycle.rst
@@ -5,7 +5,7 @@ Life Cycle of an Architecture
 
 .. TODO: Maybe add a flowchart later
 
-Architectures in `metatrain` undergo different stages based on their
+Architectures in ``metatrain`` undergo different stages based on their
 development/functionality level and maintenance status. We distinguish three distinct
 stages: **experimental**, **stable**, and **deprecated**. Typically, an architecture
 starts as experimental, advances to stable, and eventually becomes deprecated before
@@ -13,7 +13,7 @@ removal if maintenance is no longer feasible.
 
 .. note::
     The development and maintenance of an architecture must be fully undertaken by the
-    architecture's authors or maintainers. The core developers of `metatrain`
+    architecture's authors or maintainers. The core developers of ``metatrain``
     provide infrastructure and implementation support but are not responsible for the
     architecture's internal functionality or any issues that may arise therein.
 
@@ -47,7 +47,7 @@ satisfied:
 2. Comprehensive architecture documentation including a schema for verifying the
    architecture's hyperparameters.
 3. If an architecture has external dependencies, all must be publicly available on PyPI.
-4. Adherence to the standard output infrastructure of `metatrain`, including
+4. Adherence to the standard output infrastructure of ``metatrain``, including
    logging and model save locations.
 
 Deprecated Architectures

--- a/docs/src/dev-docs/cli/index.rst
+++ b/docs/src/dev-docs/cli/index.rst
@@ -12,7 +12,7 @@ the ``eval`` and the ``export`` functions of ``metatrain``.
    export
 
 We provide a custom formatter class for the formatting the help message of the
-`argparse` package.
+``argparse`` package.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/src/dev-docs/index.rst
+++ b/docs/src/dev-docs/index.rst
@@ -1,7 +1,7 @@
 Developer documentation
 =======================
 
-This is a collection of documentation for developers of the `metatrain` package.
+This is a collection of documentation for developers of the ``metatrain`` package.
 It includes documentation on how to add a new model, as well as the API of the utils
 module.
 

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -4,13 +4,14 @@ Adding a new architecture
 =========================
 
 This page describes the required classes and files necessary for adding a new
-architecture to `metatrain` as experimental or stable architecture as described on the
+architecture to ``metatrain`` as experimental or stable architecture as described on the
 :ref:`architecture-life-cycle` page. For **examples** refer to the already existing
 architectures inside the source tree.
 
-To work with `metatrain` any architecture has to follow the same public API to be called
-correctly within the :py:func:`metatrain.cli.train` function to process the user's
-options. In brief, the core of the ``train`` function looks similar to these lines
+To work with ``metatrain`` any architecture has to follow the same public API to be
+called correctly within the :py:func:`metatrain.cli.train` function to process the
+user's options. In brief, the core of the ``train`` function looks similar to these
+lines
 
 .. code-block:: python
 
@@ -30,6 +31,7 @@ options. In brief, the core of the ``train`` function looks similar to these lin
 
     trainer.train(
         model=model,
+        dtype=dtype,
         devices=[],
         train_datasets=[],
         val_datasets=[],
@@ -75,8 +77,8 @@ requirements to be stable. The usual structure of architecture looks as
 
 .. note::
     A new architecture doesn't have to be registered somewhere in the file tree of
-    `metatrain`. Once a new architecture folder with the required files is created
-    `metatrain` will include the architecture automatically.
+    ``metatrain``. Once a new architecture folder with the required files is created
+    ``metatrain`` will include the architecture automatically.
 
 Model class (``model.py``)
 --------------------------
@@ -118,8 +120,8 @@ Note that the ``ModelInterface`` does not necessarily inherit from
 :py:class:`torch.nn.Module` since training can be performed in any way.
 ``__supported_devices__`` and ``__supported_dtypes__`` can be defined to set the
 capabilities of the model. These two lists should be sorted in order of preference since
-`metatrain` will use these to determine, based on the user request and
-machines' availability, the optimal `dtype` and `device` for training.
+``metatrain`` will use these to determine, based on the user request and
+machines' availability, the optimal ``dtype`` and ``device`` for training.
 
 The ``export()`` method is required to transform a trained model into a standalone file
 to be used in combination with molecular dynamic engines to run simulations. We provide
@@ -141,6 +143,7 @@ methods for ``train()``, ``save_checkpoint()`` and ``load_checkpoint()``.
         def train(
             self,
             model: ModelInterface,
+            dtype: torch.dtype,
             devices: List[torch.device],
             train_datasets: List[Union[Dataset, torch.utils.data.Subset]],
             val_datasets: List[Union[Dataset, torch.utils.data.Subset]],
@@ -155,7 +158,7 @@ methods for ``train()``, ``save_checkpoint()`` and ``load_checkpoint()``.
         ) -> "TrainerInterface":
             pass
 
-The format of checkpoints is not defined by `metatrain` and can be any format that
+The format of checkpoints is not defined by ``metatrain`` and can be any format that
 can be loaded by the trainer (to restart training) and by the model (to export the
 checkpoint).
 
@@ -164,15 +167,15 @@ Init file (``__init__.py``)
 The names of the ``ModelInterface`` and the ``TrainerInterface`` are free to choose but
 should be linked to constants in the ``__init__.py`` of each architecture. On top of
 these two constants the ``__init__.py`` must contain constants for the original
-`__authors__` and current `__maintainers__` of the architecture.
+``__authors__`` and current ``__maintainers__`` of the architecture.
 
 .. code-block:: python
 
-    from .model import CustomSOTAModel
-    from .trainer import Trainer
+    from .model import ModelInterface
+    from .trainer import TrainerInterface
 
-    __model__ = CustomSOTAModel
-    __trainer__ = Trainer
+    __model__ = ModelInterface
+    __trainer__ = TrainerInterface
 
     __authors__ = [
         ("Jane Roe <jane.roe@myuniversity.org>", "@janeroe"),
@@ -207,7 +210,7 @@ required to improve usability. The default hypers must follow the structure
     training:
         ...
 
-`metatrain` will parse this file and overwrite these default hypers with the
+``metatrain`` will parse this file and overwrite these default hypers with the
 user-provided parameters and pass the merged ``model`` section as a Python dictionary to
 the ``ModelInterface`` and the ``training`` section to the ``TrainerInterface``.
 

--- a/docs/src/dev-docs/utils/data/readers.rst
+++ b/docs/src/dev-docs/utils/data/readers.rst
@@ -33,7 +33,7 @@ Target type specific readers
 ----------------------------
 
 :func:`metatrain.utils.data.read_targets` uses sub-functions to parse supported
-target properties like the `energy` or `forces`. Currently we support reading the
+target properties like the ``energy`` or ``forces``. Currently we support reading the
 following target properties via
 
 .. autofunction:: metatrain.utils.data.read_energy

--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -4,9 +4,9 @@ Customize a Dataset Configuration
 =================================
 Overview
 --------
-The main task in setting up a training procedure with `metatrain` is to provide
+The main task in setting up a training procedure with ``metatrain`` is to provide
 files for training, validation, and testing datasets. Our system allows flexibility in
-parsing data for training. Mandatory sections in the `options.yaml` file include:
+parsing data for training. Mandatory sections in the ``options.yaml`` file include:
 
 - ``training_set``
 - ``test_set``
@@ -78,7 +78,7 @@ A single string in this section automatically expands, using the string as the
 
 .. note::
 
-   `metatrain` does not convert units during training or evaluation. Units are
+   ``metatrain`` does not convert units during training or evaluation. Units are
    only required if model should be used to run MD simulations.
 
 Targets Section
@@ -86,8 +86,8 @@ Targets Section
 Allows defining multiple target sections, each with a unique name.
 
 - Commonly, a section named ``energy`` should be defined, which is essential for running
-  molecular dynamics simulations. For the ``energy`` section gradients like `forces` and
-  `stress` are enabled by default.
+  molecular dynamics simulations. For the ``energy`` section gradients like ``forces``
+  and ``stress`` are enabled by default.
 - Other target sections can also be defined, as long as they are prefixed by ``mtt::``.
   For example, ``mtt::free_energy``. In general, all targets that are not standard
   outputs of ``metatensor.torch.atomistic`` (see
@@ -137,7 +137,7 @@ without them.
 Multiple Datasets
 -----------------
 For some applications, it is required to provide more than one dataset for model
-training. `metatrain` supports stacking several datasets together using the
+training. ``metatrain`` supports stacking several datasets together using the
 ``YAML`` list syntax, which consists of lines beginning at the same indentation level
 starting with a ``"- "`` (a dash and a space)
 

--- a/docs/src/getting-started/usage.rst
+++ b/docs/src/getting-started/usage.rst
@@ -11,20 +11,20 @@ registered via the abbreviation ``mtt`` to your command line. The general help o
 
     mtt --help
 
-We now demonstrate how to `train` and `evaluate` a model from the command line. For this
-example we use the :ref:`architecture-soap-bpnn` architecture and a subset of the `QM9
-dataset <https://paperswithcode.com/dataset/qm9>`_. You can obtain the reduced dataset
-from our :download:`website <../../static/qm9/qm9_reduced_100.xyz>`.
+We now demonstrate how to ``train`` and ``evaluate`` a model from the command line. For
+this example we use the :ref:`architecture-soap-bpnn` architecture and a subset of the
+`QM9 dataset <https://paperswithcode.com/dataset/qm9>`_. You can obtain the reduced
+dataset from our :download:`website <../../static/qm9/qm9_reduced_100.xyz>`.
 
 Training
 ########
 
-To train models, `metatrain` uses a dynamic override strategy for your training
+To train models, ``metatrain`` uses a dynamic override strategy for your training
 options. We allow a dynamical composition and override of the default architecture with
 either your custom ``options.yaml`` and even command line override grammar. For
-reference and reproducibility purposes `metatrain` always writes the fully
+reference and reproducibility purposes ``metatrain`` always writes the fully
 expanded, including the overwritten option to ``options_restart.yaml``. The restart
-options file is written into a subfolder named with the current `date` and `time` inside
+options file is written into a subfolder named with the current *date* and *time* inside
 the ``output`` directory of your current training run.
 
 The sub-command to start a model training is
@@ -45,7 +45,7 @@ training using the default hyperparameters of an SOAP BPNN model
    :language: yaml
 
 For each training run a new output directory in the format
-``output/YYYY-MM-DD/HH-MM-SS`` based on the current `date` and `time` is created. We use
+``output/YYYY-MM-DD/HH-MM-SS`` based on the current *date* and *time* is created. We use
 this output directory to store checkpoints, the ``train.log`` log file  as well the
 restart ``options_restart.yaml`` file. To start the training create an ``options.yaml``
 file in the current directory and type
@@ -64,7 +64,7 @@ The sub-command to evaluate an already trained model is
 
     mtt eval
 
-Besides the trained `model`, you will also have to provide a file containing the
+Besides the trained ``model``, you will also have to provide a file containing the
 system and possible target values for evaluation. The system of this ``eval.yaml``
 is exactly the same as for a dataset in the ``options.yaml`` file.
 

--- a/examples/programmatic/llpr/llpr.py
+++ b/examples/programmatic/llpr/llpr.py
@@ -51,7 +51,7 @@ from metatrain.utils.data import Dataset, read_systems, read_targets  # noqa: E4
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists  # noqa: E402
 
 
-qm9_systems = read_systems("qm9_reduced_100.xyz", dtype=torch.float64)
+qm9_systems = read_systems("qm9_reduced_100.xyz")
 
 target_config = {
     "energy": {
@@ -65,7 +65,7 @@ target_config = {
         "virial": False,
     },
 }
-targets, _ = read_targets(target_config, dtype=torch.float64)
+targets, _ = read_targets(target_config)
 
 requested_neighbor_lists = model.requested_neighbor_lists()
 qm9_systems = [
@@ -77,7 +77,7 @@ dataset = Dataset({"system": qm9_systems, **targets})
 # We also load a single ethanol molecule on which we will compute properties.
 # This system is loaded without targets, as we are only interested in the LPR
 # values.
-ethanol_system = read_systems("ethanol_reduced_100.xyz", dtype=torch.float64)[0]
+ethanol_system = read_systems("ethanol_reduced_100.xyz")[0]
 ethanol_system = get_system_with_neighbor_lists(
     ethanol_system, requested_neighbor_lists
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ source = [
     ".tox/*/lib/python*/site-packages/metatrain"
 ]
 
+[tool.black]
+exclude = 'docs/src/examples'
+
 [tool.isort]
 skip = "__init__.py"
 profile = "black"
@@ -106,4 +109,8 @@ lines_after_imports = 2
 known_first_party = "metatrain"
 
 [tool.mypy]
+exclude = [
+    "docs/src/examples"
+]
+follow_imports = 'skip'
 ignore_missing_imports = true

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -168,7 +168,9 @@ def _eval_targets(
         get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
     # Infer the device from the model
-    device = next(itertools.chain(model.parameters(), model.buffers())).device
+    model_metadata = next(itertools.chain(model.parameters(), model.buffers()))
+    dtype = model_metadata.dtype
+    device = model_metadata.device
 
     # Create a dataloader
     dataloader = torch.utils.data.DataLoader(
@@ -188,9 +190,10 @@ def _eval_targets(
     # Evaluate the model
     for batch in dataloader:
         systems, batch_targets = batch
-        systems = [system.to(device=device) for system in systems]
+        systems = [system.to(dtype=dtype, device=device) for system in systems]
         batch_targets = {
-            key: value.to(device=device) for key, value in batch_targets.items()
+            key: value.to(dtype=dtype, device=device)
+            for key, value in batch_targets.items()
         }
         batch_predictions = evaluate_model(model, systems, options, is_training=False)
         batch_predictions = average_by_num_atoms(
@@ -238,10 +241,6 @@ def eval_model(
     """
     logger.info("Setting up evaluation set.")
 
-    # TODO: once https://github.com/lab-cosmo/metatensor/pull/551 is merged and released
-    # use capabilities instead of this workaround
-    dtype = next(model.parameters()).dtype
-
     if isinstance(output, str):
         output = Path(output)
 
@@ -258,13 +257,12 @@ def eval_model(
         eval_systems = read_systems(
             filename=options["systems"]["read_from"],
             reader=options["systems"]["reader"],
-            dtype=dtype,
         )
 
         if hasattr(options, "targets"):
             # in this case, we only evaluate the targets specified in the options
             # and we calculate RMSEs
-            eval_targets, eval_info_dict = read_targets(options["targets"], dtype=dtype)
+            eval_targets, eval_info_dict = read_targets(options["targets"])
         else:
             # in this case, we have no targets: we evaluate everything
             # (but we don't/can't calculate RMSEs)

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -167,10 +167,10 @@ def _eval_targets(
         system = sample["system"]
         get_system_with_neighbor_lists(system, model.requested_neighbor_lists())
 
-    # Infer the device from the model
-    model_metadata = next(itertools.chain(model.parameters(), model.buffers()))
-    dtype = model_metadata.dtype
-    device = model_metadata.device
+    # Infer the device and dtype from the model
+    model_tensor = next(itertools.chain(model.parameters(), model.buffers()))
+    dtype = model_tensor.dtype
+    device = model_tensor.device
 
     # Create a dataloader
     dataloader = torch.utils.data.DataLoader(

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -196,10 +196,12 @@ def train_model(
         train_systems = read_systems(
             filename=train_options["systems"]["read_from"],
             reader=train_options["systems"]["reader"],
-            dtype=dtype,
         )
         train_targets, target_info_dictionary = read_targets(
-            conf=train_options["targets"], dtype=dtype
+            conf=train_options["targets"]
+        )
+        train_targets, target_info_dictionary = read_targets(
+            conf=train_options["targets"]
         )
 
         target_infos.update(target_info_dictionary)
@@ -250,9 +252,8 @@ def train_model(
             test_systems = read_systems(
                 filename=test_options["systems"]["read_from"],
                 reader=test_options["systems"]["reader"],
-                dtype=dtype,
             )
-            test_targets, _ = read_targets(conf=test_options["targets"], dtype=dtype)
+            test_targets, _ = read_targets(conf=test_options["targets"])
             test_dataset = Dataset({"system": test_systems, **test_targets})
             test_datasets.append(test_dataset)
 
@@ -299,9 +300,8 @@ def train_model(
             val_systems = read_systems(
                 filename=val_options["systems"]["read_from"],
                 reader=val_options["systems"]["reader"],
-                dtype=dtype,
             )
-            val_targets, _ = read_targets(conf=val_options["targets"], dtype=dtype)
+            val_targets, _ = read_targets(conf=val_options["targets"])
             val_dataset = Dataset({"system": val_systems, **val_targets})
             val_datasets.append(val_dataset)
 
@@ -379,6 +379,7 @@ def train_model(
     try:
         trainer.train(
             model=model,
+            dtype=dtype,
             devices=devices,
             train_datasets=train_datasets,
             val_datasets=val_datasets,

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -1,7 +1,6 @@
 import random
 
 import numpy as np
-import pytest
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions
 from omegaconf import OmegaConf
@@ -36,7 +35,6 @@ def test_regression_init():
         length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
-    model.to(dtype=torch.float64)
 
     # Predict on the first five systems
     systems = read_systems(DATASET_PATH)[:5]
@@ -52,6 +50,7 @@ def test_regression_init():
 
     exported = model.export()
 
+    systems = [system.to(dtype=torch.float32) for system in systems]
     output = exported(systems, evaluation_options, check_consistency=True)
 
     expected_output = torch.tensor(
@@ -62,7 +61,6 @@ def test_regression_init():
             [-13.758152008057],
             [-2.430717945099],
         ],
-        dtype=torch.float64,
     )
 
     # if you need to change the hardcoded values:
@@ -75,8 +73,7 @@ def test_regression_init():
     )
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def test_regression_train(dtype):
+def test_regression_train():
     """Perform a regression test on the model when
     trained for 2 epoch on a small dataset"""
 
@@ -113,7 +110,7 @@ def test_regression_train(dtype):
     trainer = Trainer(hypers["training"])
     trainer.train(
         model=model,
-        dtype=dtype,
+        dtype=torch.float32,
         devices=[torch.device("cpu")],
         train_datasets=[dataset],
         val_datasets=[dataset],
@@ -128,18 +125,17 @@ def test_regression_train(dtype):
 
     exported = model.export()
 
-    systems = [system.to(dtype=dtype) for system in systems]
+    systems = [system.to(dtype=torch.float32) for system in systems]
     output = exported(systems[:5], evaluation_options, check_consistency=True)
 
     expected_output = torch.tensor(
         [
-            [-40.133975982666],
-            [-56.344772338867],
-            [-76.740966796875],
-            [-77.038444519043],
-            [-92.812789916992],
+            [-40.115474700928],
+            [-56.302265167236],
+            [-76.722442626953],
+            [-77.022941589355],
+            [-92.791801452637],
         ],
-        dtype=dtype,
     )
 
     # if you need to change the hardcoded values:

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -1,6 +1,7 @@
 import random
 
 import numpy as np
+import pytest
 import torch
 from metatensor.torch.atomistic import ModelEvaluationOptions
 from omegaconf import OmegaConf
@@ -35,6 +36,7 @@ def test_regression_init():
         length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
+    model.to(dtype=torch.float64)
 
     # Predict on the first five systems
     systems = read_systems(DATASET_PATH)[:5]
@@ -59,7 +61,8 @@ def test_regression_init():
             [-4.632149219513],
             [-13.758152008057],
             [-2.430717945099],
-        ]
+        ],
+        dtype=torch.float64,
     )
 
     # if you need to change the hardcoded values:
@@ -72,7 +75,8 @@ def test_regression_init():
     )
 
 
-def test_regression_train():
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_regression_train(dtype):
     """Perform a regression test on the model when
     trained for 2 epoch on a small dataset"""
 
@@ -109,7 +113,7 @@ def test_regression_train():
     trainer = Trainer(hypers["training"])
     trainer.train(
         model=model,
-        dtype=torch.float64,
+        dtype=dtype,
         devices=[torch.device("cpu")],
         train_datasets=[dataset],
         val_datasets=[dataset],
@@ -133,7 +137,8 @@ def test_regression_train():
             [-76.740966796875],
             [-77.038444519043],
             [-92.812789916992],
-        ]
+        ],
+        dtype=dtype,
     )
 
     # if you need to change the hardcoded values:

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -128,6 +128,7 @@ def test_regression_train(dtype):
 
     exported = model.export()
 
+    systems = [system.to(dtype=dtype) for system in systems]
     output = exported(systems[:5], evaluation_options, check_consistency=True)
 
     expected_output = torch.tensor(

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -107,7 +107,14 @@ def test_regression_train():
 
     hypers["training"]["num_epochs"] = 1
     trainer = Trainer(hypers["training"])
-    trainer.train(model, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=model,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
 
     # Predict on the first five systems
     evaluation_options = ModelEvaluationOptions(

--- a/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
@@ -25,6 +25,7 @@ np.random.seed(0)
 torch.manual_seed(0)
 
 systems = read_systems(ALCHEMICAL_DATASET_PATH)
+systems = [system.to(torch.float32) for system in systems]
 nl_options = NeighborListOptions(
     cutoff=5.0,
     full_list=True,
@@ -73,7 +74,6 @@ def test_alchemical_model_inference():
     )
 
     alchemical_model = AlchemicalModel(MODEL_HYPERS, dataset_info)
-    alchemical_model.to(dtype=torch.float64)
 
     evaluation_options = ModelEvaluationOptions(
         length_unit=dataset_info.length_unit,

--- a/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
@@ -43,13 +43,16 @@ batch = next(iter(dataloader))
 
 def test_systems_to_torch_alchemical_batch():
     batch_dict = systems_to_torch_alchemical_batch(systems, nl_options)
+    print(batch_dict["positions"].dtype, batch.pos.dtype)
     torch.testing.assert_close(batch_dict["positions"], batch.pos)
     torch.testing.assert_close(batch_dict["cells"], batch.cell)
     torch.testing.assert_close(batch_dict["numbers"], batch.numbers)
+
     index_1, counts_1 = torch.unique(batch_dict["batch"], return_counts=True)
     index_2, counts_2 = torch.unique(batch.batch, return_counts=True)
     torch.testing.assert_close(index_1, index_2)
     torch.testing.assert_close(counts_1, counts_2)
+
     offset_1, counts_1 = torch.unique(batch_dict["edge_offsets"], return_counts=True)
     offset_2, counts_2 = torch.unique(batch.edge_offsets, return_counts=True)
     torch.testing.assert_close(offset_1, offset_2)
@@ -70,6 +73,7 @@ def test_alchemical_model_inference():
     )
 
     alchemical_model = AlchemicalModel(MODEL_HYPERS, dataset_info)
+    alchemical_model.to(dtype=torch.float64)
 
     evaluation_options = ModelEvaluationOptions(
         length_unit=dataset_info.length_unit,

--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -43,12 +43,14 @@ class Trainer:
     def train(
         self,
         model: AlchemicalModel,
+        dtype: torch.dtype,
         devices: List[torch.device],
         train_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         val_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         checkpoint_dir: str,
     ):
-        dtype = train_datasets[0][0]["system"].positions.dtype
+        assert dtype in AlchemicalModel.__supported_dtypes__
+
         device = devices[0]  # only one device, as we don't support multi-gpu for now
 
         if len(model.dataset_info.targets) != 1:
@@ -216,9 +218,10 @@ class Trainer:
 
                 systems, targets = batch
                 assert len(systems[0].known_neighbor_lists()) > 0
-                systems = [system.to(device=device) for system in systems]
+                systems = [system.to(dtype=dtype, device=device) for system in systems]
                 targets = {
-                    key: value.to(device=device) for key, value in targets.items()
+                    key: value.to(dtype=dtype, device=device)
+                    for key, value in targets.items()
                 }
                 predictions = evaluate_model(
                     model,

--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -254,9 +254,10 @@ class Trainer:
             for batch in val_dataloader:
                 systems, targets = batch
                 assert len(systems[0].known_neighbor_lists()) > 0
-                systems = [system.to(device=device) for system in systems]
+                systems = [system.to(dtype=dtype, device=device) for system in systems]
                 targets = {
-                    key: value.to(device=device) for key, value in targets.items()
+                    key: value.to(dtype=dtype, device=device)
+                    for key, value in targets.items()
                 }
                 predictions = evaluate_model(
                     model,

--- a/src/metatrain/experimental/gap/model.py
+++ b/src/metatrain/experimental/gap/model.py
@@ -71,7 +71,11 @@ class GAP(torch.nn.Module):
         # set_composition_weights (recommended for better accuracy)
         n_outputs = len(dataset_info.targets)
         self.register_buffer(
-            "composition_weights", torch.zeros((n_outputs, max(self.atomic_types) + 1))
+            "composition_weights",
+            torch.zeros(
+                (n_outputs, max(self.atomic_types) + 1),
+                dtype=torch.float64,  # we only support float64 for now
+            ),
         )
         # buffers cannot be indexed by strings (torchscript), so we create a single
         # tensor for all output. Due to this, we need to slice the tensor when we use
@@ -81,7 +85,11 @@ class GAP(torch.nn.Module):
         }
 
         self.register_buffer(
-            "kernel_weights", torch.zeros((model_hypers["krr"]["num_sparse_points"]))
+            "kernel_weights",
+            torch.zeros(
+                model_hypers["krr"]["num_sparse_points"],
+                dtype=torch.float64,  # we only support float64 for now
+            ),
         )
         self._soap_torch_calculator = rascaline.torch.SoapPowerSpectrum(
             **model_hypers["soap"]

--- a/src/metatrain/experimental/gap/tests/test_errors.py
+++ b/src/metatrain/experimental/gap/tests/test_errors.py
@@ -34,7 +34,7 @@ def test_ethanol_regression_train_and_invariance():
     is bigger than the number of environments
     """
 
-    systems = read_systems(DATASET_ETHANOL_PATH, dtype=torch.float64)
+    systems = read_systems(DATASET_ETHANOL_PATH)
 
     conf = {
         "energy": {
@@ -53,7 +53,7 @@ def test_ethanol_regression_train_and_invariance():
         }
     }
 
-    targets, _ = read_targets(OmegaConf.create(conf), dtype=torch.float64)
+    targets, _ = read_targets(OmegaConf.create(conf))
     dataset = Dataset({"system": systems[:2], "energy": targets["energy"][:2]})
 
     hypers = copy.deepcopy(DEFAULT_HYPERS)
@@ -76,4 +76,11 @@ def test_ethanol_regression_train_and_invariance():
             "should be smaller than the number of environments (18)"
         ),
     ):
-        trainer.train(gap, [torch.device("cpu")], [dataset], [dataset], ".")
+        trainer.train(
+            model=gap,
+            dtype=torch.float64,
+            devices=[torch.device("cpu")],
+            train_datasets=[dataset],
+            val_datasets=[dataset],
+            checkpoint_dir=".",
+        )

--- a/src/metatrain/experimental/gap/tests/test_regression.py
+++ b/src/metatrain/experimental/gap/tests/test_regression.py
@@ -40,7 +40,7 @@ def test_regression_train_and_invariance():
     for this.
     """
 
-    systems = read_systems(DATASET_PATH, dtype=torch.float64)
+    systems = read_systems(DATASET_PATH)
 
     conf = {
         "mtt::U0": {
@@ -54,7 +54,7 @@ def test_regression_train_and_invariance():
             "virial": False,
         }
     }
-    targets, _ = read_targets(OmegaConf.create(conf), dtype=torch.float64)
+    targets, _ = read_targets(OmegaConf.create(conf))
     dataset = Dataset({"system": systems, "mtt::U0": targets["mtt::U0"]})
 
     target_info_dict = TargetInfoDict()
@@ -66,7 +66,14 @@ def test_regression_train_and_invariance():
 
     gap = GAP(DEFAULT_HYPERS["model"], dataset_info)
     trainer = Trainer(DEFAULT_HYPERS["training"])
-    trainer.train(gap, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=gap,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
 
     # Predict on the first five systems
     output = gap(systems[:5], {"mtt::U0": gap.outputs["mtt::U0"]})
@@ -105,7 +112,7 @@ def test_ethanol_regression_train_and_invariance():
     for this.
     """
 
-    systems = read_systems(DATASET_ETHANOL_PATH, dtype=torch.float64)
+    systems = read_systems(DATASET_ETHANOL_PATH)
 
     conf = {
         "energy": {
@@ -124,7 +131,7 @@ def test_ethanol_regression_train_and_invariance():
         }
     }
 
-    targets, _ = read_targets(OmegaConf.create(conf), dtype=torch.float64)
+    targets, _ = read_targets(OmegaConf.create(conf))
     dataset = Dataset({"system": systems, "energy": targets["energy"]})
 
     hypers = copy.deepcopy(DEFAULT_HYPERS)
@@ -140,7 +147,14 @@ def test_ethanol_regression_train_and_invariance():
 
     gap = GAP(hypers["model"], dataset_info)
     trainer = Trainer(hypers["training"])
-    trainer.train(gap, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=gap,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
 
     # Predict on the first five systems
     output = gap(systems[:5], {"energy": gap.outputs["energy"]})

--- a/src/metatrain/experimental/gap/tests/test_torchscript.py
+++ b/src/metatrain/experimental/gap/tests/test_torchscript.py
@@ -31,8 +31,8 @@ def test_torchscript():
             "virial": False,
         }
     }
-    targets, _ = read_targets(OmegaConf.create(conf), dtype=torch.float64)
-    systems = read_systems(DATASET_PATH, dtype=torch.float64)
+    targets, _ = read_targets(OmegaConf.create(conf))
+    systems = read_systems(DATASET_PATH)
 
     # for system in systems:
     #    system.types = torch.ones(len(system.types), dtype=torch.int32)
@@ -41,7 +41,14 @@ def test_torchscript():
     hypers = DEFAULT_HYPERS.copy()
     gap = GAP(DEFAULT_HYPERS["model"], dataset_info)
     trainer = Trainer(hypers["training"])
-    trainer.train(gap, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=gap,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
     scripted_gap = torch.jit.script(gap)
 
     ref_output = gap.forward(systems[:5], {"mtt::U0": gap.outputs["mtt::U0"]})

--- a/src/metatrain/experimental/gap/trainer.py
+++ b/src/metatrain/experimental/gap/trainer.py
@@ -25,15 +25,15 @@ class Trainer:
     def train(
         self,
         model: GAP,
+        dtype: torch.dtype,
         devices: List[torch.device],
         train_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         val_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         checkpoint_dir: str,
     ):
         # checks
+        assert dtype in GAP.__supported_dtypes__
         assert devices == [torch.device("cpu")]
-        dtype = train_datasets[0][0]["system"].positions.dtype
-        assert dtype == torch.float64
         target_name = next(iter(model.dataset_info.targets.keys()))
         if len(train_datasets) != 1:
             raise ValueError("GAP only supports a single training dataset")

--- a/src/metatrain/experimental/pet/trainer.py
+++ b/src/metatrain/experimental/pet/trainer.py
@@ -28,11 +28,14 @@ class Trainer:
     def train(
         self,
         model: WrappedPET,
+        dtype: torch.dtype,
         devices: List[torch.device],
         train_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         val_datasets: List[Union[Dataset, torch.utils.data.Subset]],
         checkpoint_dir: str,
     ):
+        assert dtype in WrappedPET.__supported_dtypes__
+
         self.pet_dir = Path(checkpoint_dir) / "pet"
 
         if len(train_datasets) != 1:

--- a/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
@@ -20,6 +20,7 @@ def test_continue(monkeypatch, tmp_path):
     shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
 
     systems = read_systems(DATASET_PATH)
+    systems = [system.to(torch.float32) for system in systems]
 
     target_info_dict = TargetInfoDict()
     target_info_dict["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
@@ -55,7 +56,7 @@ def test_continue(monkeypatch, tmp_path):
     trainer = Trainer(hypers["training"])
     trainer.train(
         model=model_after,
-        dtype=torch.float64,
+        dtype=torch.float32,
         devices=[torch.device("cpu")],
         train_datasets=[dataset],
         val_datasets=[dataset],

--- a/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
@@ -53,7 +53,14 @@ def test_continue(monkeypatch, tmp_path):
 
     hypers["training"]["num_epochs"] = 0
     trainer = Trainer(hypers["training"])
-    trainer.train(model_after, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=model_after,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
 
     # Predict on the first five systems
     output_before = model_before(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
@@ -81,7 +81,14 @@ def test_regression_train():
 
     hypers["training"]["num_epochs"] = 1
     trainer = Trainer(hypers["training"])
-    trainer.train(model, [torch.device("cpu")], [dataset], [dataset], ".")
+    trainer.train(
+        model=model,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
 
     # Predict on the first five systems
     output = model(

--- a/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
@@ -31,6 +31,7 @@ def test_regression_init():
 
     # Predict on the first five systems
     systems = read_systems(DATASET_PATH)[:5]
+    systems = [system.to(torch.float32) for system in systems]
 
     output = model(
         systems,
@@ -83,7 +84,7 @@ def test_regression_train():
     trainer = Trainer(hypers["training"])
     trainer.train(
         model=model,
-        dtype=torch.float64,
+        dtype=torch.float32,
         devices=[torch.device("cpu")],
         train_datasets=[dataset],
         val_datasets=[dataset],
@@ -91,6 +92,7 @@ def test_regression_train():
     )
 
     # Predict on the first five systems
+    systems = [system.to(torch.float32) for system in systems]
     output = model(
         systems[:5],
         {"mtt::U0": ModelOutput(quantity="energy", unit="", per_atom=False)},

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -304,9 +304,10 @@ class Trainer:
             val_loss = 0.0
             for batch in val_dataloader:
                 systems, targets = batch
-                systems = [system.to(device=device) for system in systems]
+                systems = [system.to(dtype=dtype, device=device) for system in systems]
                 targets = {
-                    key: value.to(device=device) for key, value in targets.items()
+                    key: value.to(dtype=dtype, device=device)
+                    for key, value in targets.items()
                 }
                 predictions = evaluate_model(
                     model,

--- a/src/metatrain/utils/data/readers/readers.py
+++ b/src/metatrain/utils/data/readers/readers.py
@@ -174,8 +174,10 @@ def read_targets(
     added. Other gradients are silentlty irgnored.
 
     :param conf: config containing the keys for what should be read.
-    :returns: Dictionary containing one TensorMaps for each target section in the config
-        as well as a ``TargetInfoDict`` instance containing the metadata of the targets.
+    :returns: Dictionary containing a list of TensorMaps for each target section in the
+        config as well as a :py:class:`TargetInfoDict
+        <metatrain.utils.data.TargetInfoDict>` instance containing the metadata of the
+        targets.
 
     :raises ValueError: if the target name is not valid. Valid target names are
         those that either start with ``mtt::`` or those that are in the list of

--- a/src/metatrain/utils/data/readers/readers.py
+++ b/src/metatrain/utils/data/readers/readers.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -27,9 +27,8 @@ def _base_reader(
     target: str,
     filename: str,
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
     **reader_kwargs,
-):
+) -> List[Any]:
     if reader is None:
         try:
             filesuffix = Path(filename).suffix
@@ -56,30 +55,32 @@ def _base_reader(
     except AttributeError:
         raise ValueError(f"Reader library {reader!r} can't read {target!r}.")
 
-    return reader_met(filename, dtype=dtype, **reader_kwargs)
+    data = reader_met(filename, **reader_kwargs)
+
+    # elements in data are `torch.ScriptObject`s and their `dtype` is an integer.
+    # A C++ double/torch.float64 is `7` according to
+    # https://github.com/pytorch/pytorch/blob/207564bab1c4fe42750931765734ee604032fb69/c10/core/ScalarType.h#L54-L93
+    assert all(d.dtype == 7 for d in data)
+
+    return data
 
 
 def read_energy(
     filename: str,
     target_value: str = "energy",
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read energy informations from a file.
 
     :param filename: name of the file to read
     :param target_value: target value key name to be parsed from the file.
     :param reader: reader library for parsing the file. If :py:obj:`None` the library is
-        determined from the file extension.
-    :param dtype: desired data type of returned tensor
-    :returns: target value stored stored as a :class:`metatensor.TensorBlock`
+        is tried to determined from the file extension.
+    :returns: energy stored stored in double precision as a
+        :class:`metatensor.TensorBlock`
     """
     return _base_reader(
-        target="energy",
-        filename=filename,
-        reader=reader,
-        key=target_value,
-        dtype=dtype,
+        target="energy", filename=filename, reader=reader, key=target_value
     )
 
 
@@ -87,23 +88,18 @@ def read_forces(
     filename: str,
     target_value: str = "forces",
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read force informations from a file.
 
     :param filename: name of the file to read
     :param target_value: target value key name to be parsed from the file
     :param reader: reader library for parsing the file. If :py:obj:`None` the library is
-        determined from the file extension.
-    :param dtype: desired data type of returned tensor
-    :returns: target value stored stored as a :class:`metatensor.TensorBlock`
+        is tried to determined from the file extension.
+    :returns: forces stored in double precision stored as a
+        :class:`metatensor.TensorBlock`
     """
     return _base_reader(
-        target="forces",
-        filename=filename,
-        reader=reader,
-        key=target_value,
-        dtype=dtype,
+        target="forces", filename=filename, reader=reader, key=target_value
     )
 
 
@@ -111,79 +107,66 @@ def read_stress(
     filename: str,
     target_value: str = "stress",
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read stress informations from a file.
 
     :param filename: name of the file to read
     :param target_value: target value key name to be parsed from the file.
     :param reader: reader library for parsing the file. If :py:obj:`None` the library is
-        determined from the file extension.
-    :param dtype: desired data type of returned tensor
-    :returns: target value stored stored as a :class:`metatensor.TensorBlock`
+        is tried to determined from the file extension.
+    :returns: stress stored in double precision as a :class:`metatensor.TensorBlock`
     """
     return _base_reader(
-        target="stress",
-        filename=filename,
-        reader=reader,
-        key=target_value,
-        dtype=dtype,
+        target="stress", filename=filename, reader=reader, key=target_value
     )
 
 
 def read_systems(
     filename: str,
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
 ) -> List[System]:
     """Read system informations from a file.
 
     :param filename: name of the file to read
     :param reader: reader library for parsing the file. If :py:obj:`None` the library is
-        determined from the file extension.
+        is tried to determined from the file extension.
     :param dtype: desired data type of returned tensor
     :returns: list of systems
+        determined from the file extension.
+    :returns: list of systems stored in double precision
     """
-    return _base_reader(
-        target="systems",
-        filename=filename,
-        reader=reader,
-        dtype=dtype,
-    )
+    return _base_reader(target="systems", filename=filename, reader=reader)
 
 
 def read_virial(
     filename: str,
     target_value: str = "virial",
     reader: Optional[str] = None,
-    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read virial informations from a file.
 
     :param filename: name of the file to read
     :param target_value: target value key name to be parsed from the file.
     :param reader: reader library for parsing the file. If :py:obj:`None` the library is
-        determined from the file extension.
-    :param dtype: desired data type of returned tensor
-    :returns: target value stored stored as a :class:`metatensor.TensorBlock`
+        is tried to determined from the file extension.
+    :returns: virial stored in double precision as a :class:`metatensor.TensorBlock`
     """
     return _base_reader(
         target="virial",
         filename=filename,
         reader=reader,
         key=target_value,
-        dtype=dtype,
     )
 
 
 def read_targets(
     conf: DictConfig,
-    dtype: torch.dtype = torch.float32,
 ) -> Tuple[Dict[str, List[TensorMap]], TargetInfoDict]:
     """Reading all target information from a fully expanded config.
 
-    To get such a config you can use
-    :func:`metatrain.utils.omegaconf.expand_dataset_config`.
+    To get such a config you can use :func:`expand_dataset_config
+    <metatrain.utils.omegaconf.expand_dataset_config>`. All targets are stored in double
+    precision.
 
     This function uses subfunctions like :func:`read_energy` to parse the requested
     target quantity. Currently only `energy` is a supported target property. But, within
@@ -191,7 +174,6 @@ def read_targets(
     added. Other gradients are silentlty irgnored.
 
     :param conf: config containing the keys for what should be read.
-    :param dtype: desired data type of returned tensor
     :returns: Dictionary containing one TensorMaps for each target section in the config
         as well as a ``TargetInfoDict`` instance containing the metadata of the targets.
 
@@ -219,7 +201,6 @@ def read_targets(
                 filename=target["read_from"],
                 target_value=target["key"],
                 reader=target["reader"],
-                dtype=dtype,
             )
 
             if target["forces"]:
@@ -228,7 +209,6 @@ def read_targets(
                         filename=target["forces"]["read_from"],
                         target_value=target["forces"]["key"],
                         reader=target["forces"]["reader"],
-                        dtype=dtype,
                     )
                 except Exception:
                     logger.warning(
@@ -256,7 +236,6 @@ def read_targets(
                         filename=target["stress"]["read_from"],
                         target_value=target["stress"]["key"],
                         reader=target["stress"]["reader"],
-                        dtype=dtype,
                     )
                 except Exception:
                     logger.warning(
@@ -279,7 +258,6 @@ def read_targets(
                         filename=target["virial"]["read_from"],
                         target_value=target["virial"]["key"],
                         reader=target["virial"]["reader"],
-                        dtype=dtype,
                     )
                 except Exception:
                     logger.warning(

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -463,23 +463,25 @@ def test_check_datasets():
         check_datasets([train_set], [val_set])
 
     # wrong dtype
-    systems_qm9_64_bit = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.float64
-    )
-    train_set_64_bit = Dataset({"system": systems_qm9_64_bit, **targets_qm9})
-    match = (
-        "`dtype` between datasets is inconsistent, found torch.float32 and "
-        "torch.float64 found in `val_datasets`"
-    )
-    with pytest.raises(TypeError, match=match):
-        check_datasets([train_set], [train_set_64_bit])
+    systems_qm9_32bit = [system.to(dtype=torch.float32) for system in systems_qm9]
+    targets_qm9_32bit = {
+        k: [v.to(dtype=torch.float32) for v in l] for k, l in targets_qm9.items()
+    }
+    train_set_32_bit = Dataset({"system": systems_qm9_32bit, **targets_qm9_32bit})
 
     match = (
-        "`dtype` between datasets is inconsistent, found torch.float32 and "
-        "torch.float64 found in `train_datasets`"
+        "`dtype` between datasets is inconsistent, found torch.float64 and "
+        "torch.float32 found in `val_datasets`"
     )
     with pytest.raises(TypeError, match=match):
-        check_datasets([train_set, train_set_64_bit], [val_set])
+        check_datasets([train_set], [train_set_32_bit])
+
+    match = (
+        "`dtype` between datasets is inconsistent, found torch.float64 and "
+        "torch.float32 found in `train_datasets`"
+    )
+    with pytest.raises(TypeError, match=match):
+        check_datasets([train_set, train_set_32_bit], [val_set])
 
 
 def test_collate_fn():

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -31,7 +31,7 @@ def test_read_systems(reader, monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_systems(filename, reader=reader, dtype=torch.float16)
+    results = read_systems(filename, reader=reader)
 
     assert isinstance(results, list)
     assert len(results) == len(systems)
@@ -39,7 +39,7 @@ def test_read_systems(reader, monkeypatch, tmp_path):
         assert isinstance(result, torch.ScriptObject)
 
         torch.testing.assert_close(
-            result.positions, torch.tensor(system.positions, dtype=torch.float16)
+            result.positions, torch.tensor(system.positions, dtype=torch.float64)
         )
         torch.testing.assert_close(
             result.types, torch.tensor([1, 1], dtype=torch.int32)
@@ -66,14 +66,12 @@ def test_read_energies(reader, monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_energy(
-        filename, reader=reader, target_value="true_energy", dtype=torch.float16
-    )
+    results = read_energy(filename, reader=reader, target_value="true_energy")
 
     assert type(results) is list
     assert len(results) == len(systems)
     for i_system, result in enumerate(results):
-        assert result.values.dtype is torch.float16
+        assert result.values.dtype is torch.float64
         assert result.samples.names == ["system"]
         assert result.samples.values == torch.tensor([[i_system]])
         assert result.properties == Labels("energy", torch.tensor([[0]]))
@@ -87,14 +85,12 @@ def test_read_forces(reader, monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_forces(
-        filename, reader=reader, target_value="forces", dtype=torch.float16
-    )
+    results = read_forces(filename, reader=reader, target_value="forces")
 
     assert type(results) is list
     assert len(results) == len(systems)
     for i_system, result in enumerate(results):
-        assert result.values.dtype is torch.float16
+        assert result.values.dtype is torch.float64
         assert result.samples.names == ["sample", "system", "atom"]
         assert torch.all(result.samples["sample"] == torch.tensor(0))
         assert torch.all(result.samples["system"] == torch.tensor(i_system))
@@ -111,9 +107,7 @@ def test_read_stress_virial(reader_func, reader, monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = reader_func(
-        filename, reader=reader, target_value="stress-3x3", dtype=torch.float16
-    )
+    results = reader_func(filename, reader=reader, target_value="stress-3x3")
 
     assert type(results) is list
     assert len(results) == len(systems)
@@ -122,7 +116,7 @@ def test_read_stress_virial(reader_func, reader, monkeypatch, tmp_path):
         Labels(["xyz_2"], torch.arange(3).reshape(-1, 1)),
     ]
     for result in results:
-        assert result.values.dtype is torch.float16
+        assert result.values.dtype is torch.float64
         assert result.samples.names == ["sample"]
         assert result.samples.values == torch.tensor([[0]])
         assert result.components == components
@@ -179,7 +173,7 @@ def test_read_targets(stress_dict, virial_dict, monkeypatch, tmp_path, caplog):
     }
 
     caplog.set_level(logging.INFO)
-    result, target_info_dict = read_targets(OmegaConf.create(conf), dtype=torch.float16)
+    result, target_info_dict = read_targets(OmegaConf.create(conf))
 
     assert any(["Forces found" in rec.message for rec in caplog.records])
 
@@ -206,12 +200,12 @@ def test_read_targets(stress_dict, virial_dict, monkeypatch, tmp_path, caplog):
             assert target.keys == Labels(["_"], torch.tensor([[0]]))
 
             result_block = target.block()
-            assert result_block.values.dtype is torch.float16
+            assert result_block.values.dtype is torch.float64
             assert result_block.samples.names == ["system"]
             assert result_block.properties == Labels("energy", torch.tensor([[0]]))
 
             pos_grad = result_block.gradient("positions")
-            assert pos_grad.values.dtype is torch.float16
+            assert pos_grad.values.dtype is torch.float64
             assert pos_grad.samples.names == ["sample", "system", "atom"]
             assert pos_grad.components == [
                 Labels(["xyz"], torch.arange(3).reshape(-1, 1))
@@ -223,7 +217,7 @@ def test_read_targets(stress_dict, virial_dict, monkeypatch, tmp_path, caplog):
                 Labels(["xyz_1"], torch.arange(3).reshape(-1, 1)),
                 Labels(["xyz_2"], torch.arange(3).reshape(-1, 1)),
             ]
-            assert strain_grad.values.dtype is torch.float16
+            assert strain_grad.values.dtype is torch.float64
             assert strain_grad.samples.names == ["sample"]
             assert strain_grad.components == components
             assert strain_grad.properties == Labels("energy", torch.tensor([[0]]))

--- a/tests/utils/data/test_target_writers.py
+++ b/tests/utils/data/test_target_writers.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List, Tuple
 
 import ase.io
 import pytest
@@ -9,7 +9,9 @@ from metatensor.torch.atomistic import ModelCapabilities, ModelOutput, System
 from metatrain.utils.data.writers import write_predictions, write_xyz
 
 
-def systems_capabilities_predictions(cell: torch.tensor = None) -> List[System]:
+def systems_capabilities_predictions(
+    cell: torch.tensor = None,
+) -> Tuple[List[System], ModelCapabilities, Dict[str, TensorMap]]:
     if cell is None:
         cell = torch.zeros((3, 3))
 

--- a/tests/utils/data/test_targets_ase.py
+++ b/tests/utils/data/test_targets_ase.py
@@ -67,10 +67,10 @@ def test_read_energy_ase(monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_energy_ase(filename=filename, key="true_energy", dtype=torch.float16)
+    results = read_energy_ase(filename=filename, key="true_energy")
 
     for result, atoms in zip(results, systems):
-        expected = torch.tensor([[atoms.info["true_energy"]]], dtype=torch.float16)
+        expected = torch.tensor([[atoms.info["true_energy"]]], dtype=torch.float64)
         torch.testing.assert_close(result.values, expected)
 
 
@@ -105,10 +105,10 @@ def test_read_forces_ase(monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_forces_ase(filename=filename, key="forces", dtype=torch.float16)
+    results = read_forces_ase(filename=filename, key="forces")
 
     for result, atoms in zip(results, systems):
-        expected = -torch.tensor(atoms.get_array("forces"), dtype=torch.float16)
+        expected = -torch.tensor(atoms.get_array("forces"), dtype=torch.float64)
         expected = expected.reshape(-1, 3, 1)
         torch.testing.assert_close(result.values, expected)
 
@@ -121,11 +121,11 @@ def test_read_stress_ase(monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_stress_ase(filename=filename, key="stress-3x3", dtype=torch.float16)
+    results = read_stress_ase(filename=filename, key="stress-3x3")
 
     for result, atoms in zip(results, systems):
         expected = atoms.cell.volume * torch.tensor(
-            atoms.info["stress-3x3"], dtype=torch.float16
+            atoms.info["stress-3x3"], dtype=torch.float64
         )
         expected = expected.reshape(-1, 3, 3, 1)
         torch.testing.assert_close(result.values, expected)
@@ -154,10 +154,10 @@ def test_read_virial_ase(monkeypatch, tmp_path):
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = read_virial_ase(filename=filename, key="stress-3x3", dtype=torch.float16)
+    results = read_virial_ase(filename=filename, key="stress-3x3")
 
     for result, atoms in zip(results, systems):
-        expected = -torch.tensor(atoms.info["stress-3x3"], dtype=torch.float16)
+        expected = -torch.tensor(atoms.info["stress-3x3"], dtype=torch.float64)
         expected = expected.reshape(-1, 3, 3, 1)
         torch.testing.assert_close(result.values, expected)
 
@@ -173,7 +173,7 @@ def test_read_virial_warn(monkeypatch, tmp_path):
     with pytest.warns(match="Found 9-long numerical vector"):
         results = read_virial_ase(filename=filename, key="stress-9")
 
-    expected = -torch.tensor(systems.info["stress-9"])
+    expected = -torch.tensor(systems.info["stress-9"], dtype=torch.float64)
     expected = expected.reshape(-1, 3, 3, 1)
     torch.testing.assert_close(results[0].values, expected)
 

--- a/tests/utils/test_evaluate_model.py
+++ b/tests/utils/test_evaluate_model.py
@@ -50,6 +50,7 @@ def test_evaluate_model(training, exported):
             for system in systems
         ]
 
+    systems = [system.to(torch.float32) for system in systems]
     outputs = evaluate_model(model, systems, targets, is_training=training)
 
     assert isinstance(outputs, dict)

--- a/tests/utils/test_llpr.py
+++ b/tests/utils/test_llpr.py
@@ -23,9 +23,7 @@ def test_llpr(tmpdir):
         str(RESOURCES_PATH / "model-64-bit.pt"),
         extensions_directory=str(RESOURCES_PATH / "extensions/"),
     )
-    qm9_systems = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.float64
-    )
+    qm9_systems = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")
     target_config = {
         "energy": {
             "quantity": "energy",
@@ -38,7 +36,7 @@ def test_llpr(tmpdir):
             "virial": False,
         },
     }
-    targets, _ = read_targets(target_config, dtype=torch.float64)
+    targets, _ = read_targets(target_config)
     requested_neighbor_lists = model.requested_neighbor_lists()
     qm9_systems = [
         get_system_with_neighbor_lists(system, requested_neighbor_lists)

--- a/tests/utils/test_output_gradient.py
+++ b/tests/utils/test_output_gradient.py
@@ -24,6 +24,7 @@ def test_forces(is_training):
         },
     )
     model = __model__(model_hypers=MODEL_HYPERS, dataset_info=dataset_info)
+    model.to(dtype=torch.float64)
 
     systems = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")[:5]
     systems = [
@@ -99,6 +100,7 @@ def test_virial(is_training):
         },
     )
     model = __model__(model_hypers=MODEL_HYPERS, dataset_info=dataset_info)
+    model.to(dtype=torch.float64)
 
     systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
@@ -189,6 +191,8 @@ def test_both(is_training):
         },
     )
     model = __model__(model_hypers=MODEL_HYPERS, dataset_info=dataset_info)
+    model.to(dtype=torch.float64)
+
     systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
     # Here we re-create strains and systems, otherwise torch

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,10 @@ commands =
     black --check --diff {[testenv]lint_folders}
     blackdoc --check --diff {[testenv]lint_folders} "{toxinidir}/README.rst"
     isort --check-only --diff {[testenv]lint_folders}
-    mypy --check-untyped-defs "{toxinidir}/src/"
-    sphinx-lint --enable line-too-long --max-line-length 88 \
+    mypy {[testenv]lint_folders}
+    sphinx-lint \
+        --enable all \
+        --max-line-length 88 \
         -i "{toxinidir}/docs/src/examples" \
         {[testenv]lint_folders} "{toxinidir}/README.rst"
 


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

As discussed with @frostedoyster it seems to be good idea to read all information from files in **double** precision and let the model decide when to convert them to the user requested precision. This is in particular useful when subtracting composition energies. Usually, composition energies are very large and one may end up with round-off errors when not doing these operations in the highest precision.

I also extended the `mypy` linter to all to be linted files and I also enabled all features of the sphinx-linter

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~[ ] Issue referenced (for PRs that solve an issue)?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--294.org.readthedocs.build/en/294/

<!-- readthedocs-preview metatrain end -->