### PR TITLE
Change `atomic_types` and `gradients` from Sets to Unique Lists

### DIFF
--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -271,10 +271,10 @@ def eval_model(
             # TODO: allow the user to specify which outputs to evaluate
             eval_targets = {}
             eval_info_dict = TargetInfoDict()
-            gradients = {"positions"}
+            gradients = ["positions"]
             if all(not torch.all(system.cell == 0) for system in eval_systems):
                 # only add strain if all structures have cells
-                gradients.add("strain")
+                gradients.append("strain")
             for key in model.capabilities().outputs.keys():
                 eval_info_dict[key] = TargetInfo(
                     quantity=model.capabilities().outputs[key].quantity,

--- a/src/metatrain/experimental/alchemical_model/model.py
+++ b/src/metatrain/experimental/alchemical_model/model.py
@@ -27,7 +27,7 @@ class AlchemicalModel(torch.nn.Module):
         super().__init__()
         self.hypers = model_hypers
         self.dataset_info = dataset_info
-        self.atomic_types = sorted(dataset_info.atomic_types)
+        self.atomic_types = dataset_info.atomic_types
 
         if len(dataset_info.targets) != 1:
             raise ValueError("The AlchemicalModel only supports a single target")

--- a/src/metatrain/experimental/alchemical_model/tests/test_exported.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_exported.py
@@ -18,7 +18,7 @@ def test_to(device, dtype):
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info).to(dtype=dtype)

--- a/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_functionality.py
@@ -14,7 +14,7 @@ def test_prediction_subset_elements():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_invariance.py
@@ -16,7 +16,7 @@ def test_rotational_invariance():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)

--- a/src/metatrain/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_regression.py
@@ -32,7 +32,7 @@ def test_regression_init():
     targets["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 
@@ -96,7 +96,7 @@ def test_regression_train():
     hypers = DEFAULT_HYPERS.copy()
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
@@ -65,7 +65,7 @@ def test_alchemical_model_inference():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types=set(unique_numbers),
+        atomic_types=unique_numbers,
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 

--- a/src/metatrain/experimental/alchemical_model/tests/test_torchscript.py
+++ b/src/metatrain/experimental/alchemical_model/tests/test_torchscript.py
@@ -11,7 +11,7 @@ def test_torchscript():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 
@@ -24,7 +24,7 @@ def test_torchscript_save_load():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = AlchemicalModel(MODEL_HYPERS, dataset_info)

--- a/src/metatrain/experimental/gap/model.py
+++ b/src/metatrain/experimental/gap/model.py
@@ -63,7 +63,7 @@ class GAP(torch.nn.Module):
             for key, value in dataset_info.targets.items()
         }
 
-        self.atomic_types = sorted(dataset_info.atomic_types)
+        self.atomic_types = dataset_info.atomic_types
         self.hypers = model_hypers
 
         # creates a composition weight tensor that can be directly indexed by species,

--- a/src/metatrain/experimental/gap/tests/test_errors.py
+++ b/src/metatrain/experimental/gap/tests/test_errors.py
@@ -64,7 +64,7 @@ def test_ethanol_regression_train_and_invariance():
     )
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
 
     gap = GAP(hypers["model"], dataset_info)

--- a/src/metatrain/experimental/gap/tests/test_regression.py
+++ b/src/metatrain/experimental/gap/tests/test_regression.py
@@ -29,7 +29,7 @@ def test_regression_init():
     targets["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
     )
     GAP(DEFAULT_HYPERS["model"], dataset_info)
 
@@ -61,7 +61,7 @@ def test_regression_train_and_invariance():
     target_info_dict["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
 
     gap = GAP(DEFAULT_HYPERS["model"], dataset_info)
@@ -135,7 +135,7 @@ def test_ethanol_regression_train_and_invariance():
     )
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
 
     gap = GAP(hypers["model"], dataset_info)

--- a/src/metatrain/experimental/gap/tests/test_torchscript.py
+++ b/src/metatrain/experimental/gap/tests/test_torchscript.py
@@ -17,7 +17,7 @@ def test_torchscript():
     target_info_dict["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
     conf = {
         "mtt::U0": {
@@ -61,7 +61,7 @@ def test_torchscript_save():
     targets["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
     )
     gap = GAP(DEFAULT_HYPERS["model"], dataset_info)
     torch.jit.save(

--- a/src/metatrain/experimental/pet/model.py
+++ b/src/metatrain/experimental/pet/model.py
@@ -43,7 +43,7 @@ class PET(torch.nn.Module):
         model_hypers["TARGET_AGGREGATION"] = "sum"
         self.hypers = model_hypers
         self.cutoff = self.hypers["R_CUT"]
-        self.atomic_types: List[int] = sorted(dataset_info.atomic_types)
+        self.atomic_types: List[int] = dataset_info.atomic_types
         self.dataset_info = dataset_info
         self.pet = None
         self.checkpoint_path: Optional[str] = None

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -28,7 +28,7 @@ def test_to(device):
     dtype = torch.float32  # for now
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)

--- a/src/metatrain/experimental/pet/tests/test_functionality.py
+++ b/src/metatrain/experimental/pet/tests/test_functionality.py
@@ -61,7 +61,7 @@ def test_prediction():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
@@ -110,7 +110,7 @@ def test_per_atom_predictions_functionality():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
@@ -160,7 +160,7 @@ def test_selected_atoms_functionality():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)

--- a/src/metatrain/experimental/pet/tests/test_pet_compatibility.py
+++ b/src/metatrain/experimental/pet/tests/test_pet_compatibility.py
@@ -91,16 +91,15 @@ def test_predictions_compatibility(cutoff):
     are consistent with the predictions of the original PET implementation."""
 
     structure = ase.io.read(DATASET_PATH)
-    atomic_types = set(structure.numbers)
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types=atomic_types,
+        atomic_types=structure.numbers,
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     capabilities = ModelCapabilities(
         length_unit="Angstrom",
-        atomic_types=sorted(atomic_types),
+        atomic_types=dataset_info.atomic_types,
         outputs={
             "energy": ModelOutput(
                 quantity="energy",
@@ -116,7 +115,7 @@ def test_predictions_compatibility(cutoff):
     hypers["R_CUT"] = cutoff
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
-    raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
+    raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(dataset_info.atomic_types))
     model.set_trained_model(raw_pet)
 
     system = systems_to_torch(structure)
@@ -142,7 +141,7 @@ def test_predictions_compatibility(cutoff):
     ARCHITECTURAL_HYPERS = Hypers(DEFAULT_HYPERS["model"])
     batch = get_pyg_graphs(
         [structure],
-        sorted(atomic_types),
+        dataset_info.atomic_types,
         cutoff,
         ARCHITECTURAL_HYPERS.USE_ADDITIONAL_SCALAR_ATTRIBUTES,
         ARCHITECTURAL_HYPERS.USE_LONG_RANGE,

--- a/src/metatrain/experimental/pet/tests/test_torchscript.py
+++ b/src/metatrain/experimental/pet/tests/test_torchscript.py
@@ -15,7 +15,7 @@ def test_torchscript():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
@@ -30,7 +30,7 @@ def test_torchscript_save_load():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)

--- a/src/metatrain/experimental/soap_bpnn/model.py
+++ b/src/metatrain/experimental/soap_bpnn/model.py
@@ -103,7 +103,7 @@ class SoapBpnn(torch.nn.Module):
         self.hypers = model_hypers
         self.dataset_info = dataset_info
         self.new_outputs = list(dataset_info.targets.keys())
-        self.atomic_types = sorted(dataset_info.atomic_types)
+        self.atomic_types = dataset_info.atomic_types
 
         self.soap_calculator = rascaline.torch.SoapPowerSpectrum(
             radial_basis={"Gto": {}}, **self.hypers["soap"]
@@ -198,7 +198,9 @@ class SoapBpnn(torch.nn.Module):
     def restart(self, dataset_info: DatasetInfo) -> "SoapBpnn":
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
-        new_atomic_types = merged_info.atomic_types - self.dataset_info.atomic_types
+        new_atomic_types = sorted(
+            set(merged_info.atomic_types) - set(self.dataset_info.atomic_types)
+        )
         new_targets = merged_info.targets - self.dataset_info.targets
 
         if len(new_atomic_types) > 0:
@@ -212,7 +214,7 @@ class SoapBpnn(torch.nn.Module):
             self.add_output(output_name)
 
         self.dataset_info = merged_info
-        self.atomic_types = sorted(self.dataset_info.atomic_types)
+        self.atomic_types = sorted(self.atomic_types)
 
         for target_name, target in new_targets.items():
             self.outputs[target_name] = ModelOutput(

--- a/src/metatrain/experimental/soap_bpnn/model.py
+++ b/src/metatrain/experimental/soap_bpnn/model.py
@@ -198,9 +198,9 @@ class SoapBpnn(torch.nn.Module):
     def restart(self, dataset_info: DatasetInfo) -> "SoapBpnn":
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
-        new_atomic_types = sorted(
-            set(merged_info.atomic_types) - set(self.dataset_info.atomic_types)
-        )
+        new_atomic_types = [
+            at for at in merged_info.atomic_types if at not in self.atomic_types
+        ]
         new_targets = merged_info.targets - self.dataset_info.targets
 
         if len(new_atomic_types) > 0:

--- a/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_continue.py
@@ -25,7 +25,7 @@ def test_continue(monkeypatch, tmp_path):
     target_info_dict["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
     output_before = model(systems[:5], {"mtt::U0": model.outputs["mtt::U0"]})

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -18,7 +18,7 @@ def test_to(device, dtype):
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info).to(dtype=dtype)

--- a/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_functionality.py
@@ -14,7 +14,7 @@ def test_prediction_subset_elements():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 
@@ -37,7 +37,7 @@ def test_prediction_subset_atoms():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 
@@ -103,7 +103,7 @@ def test_output_last_layer_features():
     """Tests that the model can output its last layer features."""
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 
@@ -174,7 +174,7 @@ def test_output_per_atom():
     """Tests that the model can output per-atom quantities."""
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_invariance.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_invariance.py
@@ -15,7 +15,7 @@ def test_rotational_invariance():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)

--- a/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_regression.py
@@ -25,7 +25,7 @@ def test_regression_init():
     targets["mtt::U0"] = TargetInfo(quantity="energy", unit="eV")
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=targets
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
@@ -75,7 +75,7 @@ def test_regression_train():
     hypers["training"]["num_epochs"] = 2
 
     dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types={1, 6, 7, 8}, targets=target_info_dict
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -14,7 +14,7 @@ def test_torchscript():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
@@ -38,7 +38,7 @@ def test_torchscript_with_identity():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     hypers = copy.deepcopy(MODEL_HYPERS)
@@ -64,7 +64,7 @@ def test_torchscript_save_load():
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
-        atomic_types={1, 6, 7, 8},
+        atomic_types=[1, 6, 7, 8],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="eV")),
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)

--- a/src/metatrain/utils/data/readers/readers.py
+++ b/src/metatrain/utils/data/readers/readers.py
@@ -205,7 +205,7 @@ def read_targets(
     standard_outputs_list = ["energy"]
 
     for target_key, target in conf.items():
-        target_info_gradients = set()
+        target_info_gradients: List[str] = []
 
         if target_key not in standard_outputs_list and not target_key.startswith(
             "mtt::"
@@ -245,7 +245,7 @@ def read_targets(
                             parameter="positions", gradient=position_gradient
                         )
 
-                    target_info_gradients.add("positions")
+                    target_info_gradients.append("positions")
 
             if target["stress"] and target["virial"]:
                 raise ValueError("Cannot use stress and virial at the same time!")
@@ -271,7 +271,7 @@ def read_targets(
                     for block, strain_gradient in zip(blocks, strain_gradients):
                         block.add_gradient(parameter="strain", gradient=strain_gradient)
 
-                    target_info_gradients.add("strain")
+                    target_info_gradients.append("strain")
 
             if target["virial"]:
                 try:
@@ -294,7 +294,7 @@ def read_targets(
                     for block, strain_gradient in zip(blocks, strain_gradients):
                         block.add_gradient(parameter="strain", gradient=strain_gradient)
 
-                    target_info_gradients.add("strain")
+                    target_info_gradients.append("strain")
         else:
             raise ValueError(
                 f"Quantity: {target['quantity']!r} is not supported. Choose 'energy'."

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -55,14 +55,14 @@ def test_target_info_gradients():
     assert target_info.__repr__() == expected
 
 
-def test_set_gradients():
+def test_list_gradients():
     info1 = TargetInfo(quantity="energy", unit="eV")
 
-    info1.gradients = ["psoitions"]
-    assert info1.gradients == ["psoitions"]
+    info1.gradients = ["positions"]
+    assert info1.gradients == ["positions"]
 
     info1.gradients += ["strain"]
-    assert info1.gradients == ["psoitions", "strain"]
+    assert info1.gradients == ["positions", "strain"]
 
 
 def test_unit_none_conversion():

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -27,18 +27,42 @@ def test_target_info_default():
     assert target_info.quantity == "energy"
     assert target_info.unit == "kcal/mol"
     assert target_info.per_atom is False
-    assert target_info.gradients == set()
+    assert target_info.gradients == []
+
+    expected = (
+        "TargetInfo(quantity='energy', unit='kcal/mol', per_atom=False, gradients=[])"
+    )
+    assert target_info.__repr__() == expected
 
 
 def test_target_info_gradients():
     target_info = TargetInfo(
-        quantity="energy", unit="kcal/mol", per_atom=True, gradients=["positions"]
+        quantity="energy",
+        unit="kcal/mol",
+        per_atom=True,
+        gradients=["positions", "positions"],
     )
 
     assert target_info.quantity == "energy"
     assert target_info.unit == "kcal/mol"
     assert target_info.per_atom is True
-    assert target_info.gradients == {"positions"}
+    assert target_info.gradients == ["positions"]
+
+    expected = (
+        "TargetInfo(quantity='energy', unit='kcal/mol', per_atom=True, "
+        "gradients=['positions'])"
+    )
+    assert target_info.__repr__() == expected
+
+
+def test_set_gradients():
+    info1 = TargetInfo(quantity="energy", unit="eV")
+
+    info1.gradients = ["psoitions"]
+    assert info1.gradients == ["psoitions"]
+
+    info1.gradients += ["strain"]
+    assert info1.gradients == ["psoitions", "strain"]
 
 
 def test_unit_none_conversion():
@@ -49,32 +73,51 @@ def test_unit_none_conversion():
 def test_length_unit_none_conversion():
     dataset_info = DatasetInfo(
         length_unit=None,
-        atomic_types={1, 2, 3},
+        atomic_types=[1, 2, 3],
         targets=TargetInfoDict(energy=TargetInfo(quantity="energy", unit="kcal/mol")),
     )
     assert dataset_info.length_unit == ""
 
 
 def test_target_info_copy():
-    info = TargetInfo(quantity="energy", unit="eV", gradients={"positions"})
+    info = TargetInfo(quantity="energy", unit="eV", gradients=["positions"])
     copy = info.copy()
     assert copy == info
     assert copy is not info
 
 
+def test_target_info_eq():
+    info1 = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    info2 = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
+
+    assert info1 == info1
+    assert info1 != info2
+
+
+def test_target_info_eq_error():
+    info = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+
+    match = (
+        "Comparison between a TargetInfo instance and a list instance is not "
+        "implemented."
+    )
+    with pytest.raises(NotImplementedError, match=match):
+        _ = info == [1, 2, 3]
+
+
 def test_target_info_update():
-    info1 = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    info2 = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    info1 = TargetInfo(quantity="energy", unit="eV", gradients=["strain", "aaa"])
+    info2 = TargetInfo(quantity="energy", unit="eV", gradients=["positions"])
     info1.update(info2)
-    assert set(info1.gradients) == {"position", "strain"}
+    assert info1.gradients == ["aaa", "positions", "strain"]
 
 
 def test_target_info_union():
-    info1 = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    info2 = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    info1 = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    info2 = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
     info_new = info1.union(info2)
     assert isinstance(info_new, TargetInfo)
-    assert set(info_new.gradients) == {"position", "strain"}
+    assert info_new.gradients == ["position", "strain"]
 
 
 def test_target_info_update_non_matching_quantity():
@@ -103,18 +146,18 @@ def test_target_info_update_non_matching_per_atom():
 
 def test_target_info_dict_setitem_new_entry():
     tid = TargetInfoDict()
-    info = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
+    info = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
     tid["energy"] = info
     assert tid["energy"] == info
 
 
 def test_target_info_dict_setitem_update_entry():
     tid = TargetInfoDict()
-    info1 = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    info2 = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    info1 = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    info2 = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
     tid["energy"] = info1
     tid["energy"] = info2
-    assert set(tid["energy"].gradients) == {"position", "strain"}
+    assert tid["energy"].gradients == ["position", "strain"]
 
 
 def test_target_info_dict_setitem_value_error():
@@ -125,10 +168,10 @@ def test_target_info_dict_setitem_value_error():
 
 def test_target_info_dict_union():
     tid1 = TargetInfoDict()
-    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
+    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
 
     tid2 = TargetInfoDict()
-    tid2["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    tid2["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
 
     merged = tid1.union(tid2)
     assert merged["energy"] == tid1["energy"]
@@ -137,11 +180,11 @@ def test_target_info_dict_union():
 
 def test_target_info_dict_merge_error():
     tid1 = TargetInfoDict()
-    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
+    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
 
     tid2 = TargetInfoDict()
     tid2["energy"] = TargetInfo(
-        quantity="energy", unit="kcal/mol", gradients={"strain"}
+        quantity="energy", unit="kcal/mol", gradients=["strain"]
     )
 
     match = r"Can't update TargetInfo with a different `unit`: \(eV != kcal/mol\)"
@@ -151,11 +194,11 @@ def test_target_info_dict_merge_error():
 
 def test_target_info_dict_intersection():
     tid1 = TargetInfoDict()
-    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
 
     tid2 = TargetInfoDict()
-    tid2["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    tid2["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
 
     intersection = tid1.intersection(tid2)
     assert len(intersection) == 1
@@ -168,12 +211,12 @@ def test_target_info_dict_intersection():
 
 def test_target_info_dict_intersection_error():
     tid1 = TargetInfoDict()
-    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
 
     tid2 = TargetInfoDict()
     tid2["myenergy"] = TargetInfo(
-        quantity="energy", unit="kcal/mol", gradients={"strain"}
+        quantity="energy", unit="kcal/mol", gradients=["strain"]
     )
 
     match = (
@@ -186,14 +229,13 @@ def test_target_info_dict_intersection_error():
 
 
 def test_target_info_dict_difference():
-    # TODO test `-` operator
     tid1 = TargetInfoDict()
-    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients={"position"})
-    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients={"strain"})
+    tid1["energy"] = TargetInfo(quantity="energy", unit="eV", gradients=["position"])
+    tid1["myenergy"] = TargetInfo(quantity="energy", unit="eV", gradients=["strain"])
 
     tid2 = TargetInfoDict()
     tid2["myenergy"] = TargetInfo(
-        quantity="energy", unit="kcal/mol", gradients={"strain"}
+        quantity="energy", unit="kcal/mol", gradients=["strain"]
     )
 
     difference = tid1.difference(tid2)
@@ -211,22 +253,43 @@ def test_dataset_info():
     targets["mtt::U0"] = TargetInfo(quantity="energy", unit="kcal/mol")
 
     dataset_info = DatasetInfo(
-        length_unit="angstrom", atomic_types={1, 2, 3}, targets=targets
+        length_unit="angstrom", atomic_types=[3, 1, 2], targets=targets
     )
 
     assert dataset_info.length_unit == "angstrom"
-    assert dataset_info.atomic_types == {1, 2, 3}
+    assert dataset_info.atomic_types == [1, 2, 3]
     assert dataset_info.targets["energy"].quantity == "energy"
     assert dataset_info.targets["energy"].unit == "kcal/mol"
     assert dataset_info.targets["mtt::U0"].quantity == "energy"
     assert dataset_info.targets["mtt::U0"].unit == "kcal/mol"
+
+    expected = (
+        "DatasetInfo(length_unit='angstrom', atomic_types=[1, 2, 3], "
+        f"targets={targets})"
+    )
+    assert dataset_info.__repr__() == expected
+
+
+def test_set_atomic_types():
+    targets = TargetInfoDict(energy=TargetInfo(quantity="energy", unit="kcal/mol"))
+    targets["mtt::U0"] = TargetInfo(quantity="energy", unit="kcal/mol")
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom", atomic_types=[3, 1, 2], targets=targets
+    )
+
+    dataset_info.atomic_types = [5, 4, 1]
+    assert dataset_info.atomic_types == [1, 4, 5]
+
+    dataset_info.atomic_types += [7, 1]
+    assert dataset_info.atomic_types == [1, 4, 5, 7]
 
 
 def test_dataset_info_copy():
     targets = TargetInfoDict()
     targets["energy"] = TargetInfo(quantity="energy", unit="eV")
     targets["forces"] = TargetInfo(quantity="mtt::forces", unit="eV/Angstrom")
-    info = DatasetInfo(length_unit="angstrom", atomic_types={1, 6}, targets=targets)
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
     copy = info.copy()
 
@@ -238,15 +301,15 @@ def test_dataset_info_update():
     targets = TargetInfoDict()
     targets["energy"] = TargetInfo(quantity="energy", unit="eV")
 
-    info = DatasetInfo(length_unit="angstrom", atomic_types={1, 6}, targets=targets)
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
     targets2 = targets.copy()
     targets2["forces"] = TargetInfo(quantity="mtt::forces", unit="eV/Angstrom")
 
-    info2 = DatasetInfo(length_unit="angstrom", atomic_types={8}, targets=targets2)
+    info2 = DatasetInfo(length_unit="angstrom", atomic_types=[8], targets=targets2)
     info.update(info2)
 
-    assert info.atomic_types == {1, 6, 8}
+    assert info.atomic_types == [1, 6, 8]
     assert info.targets["energy"] == targets["energy"]
     assert info.targets["forces"] == targets2["forces"]
 
@@ -255,12 +318,12 @@ def test_dataset_info_update_non_matching_length_unit():
     targets = TargetInfoDict()
     targets["energy"] = TargetInfo(quantity="energy", unit="eV")
 
-    info = DatasetInfo(length_unit="angstrom", atomic_types={1, 6}, targets=targets)
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
     targets2 = targets.copy()
     targets2["forces"] = TargetInfo(quantity="mtt::forces", unit="eV/Angstrom")
 
-    info2 = DatasetInfo(length_unit="nanometer", atomic_types={8}, targets=targets2)
+    info2 = DatasetInfo(length_unit="nanometer", atomic_types=[8], targets=targets2)
 
     match = (
         r"Can't update DatasetInfo with a different `length_unit`: "
@@ -271,16 +334,44 @@ def test_dataset_info_update_non_matching_length_unit():
         info.update(info2)
 
 
+def test_dataset_info_eq():
+    targets = TargetInfoDict()
+    targets["energy"] = TargetInfo(quantity="energy", unit="eV")
+
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
+
+    targets2 = targets.copy()
+    targets2["forces"] = TargetInfo(quantity="mtt::forces", unit="eV/Angstrom")
+    info2 = DatasetInfo(length_unit="nanometer", atomic_types=[8], targets=targets2)
+
+    assert info == info
+    assert info != info2
+
+
+def test_dataset_info_eq_error():
+    targets = TargetInfoDict()
+    targets["energy"] = TargetInfo(quantity="energy", unit="eV")
+
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
+
+    match = (
+        "Comparison between a DatasetInfo instance and a list instance is not "
+        "implemented."
+    )
+    with pytest.raises(NotImplementedError, match=match):
+        _ = info == [1, 2, 3]
+
+
 def test_dataset_info_update_different_target_info():
     targets = TargetInfoDict()
     targets["energy"] = TargetInfo(quantity="energy", unit="eV")
 
-    info = DatasetInfo(length_unit="angstrom", atomic_types={1, 6}, targets=targets)
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
     targets2 = TargetInfoDict()
     targets2["energy"] = TargetInfo(quantity="energy", unit="eV/Angstrom")
 
-    info2 = DatasetInfo(length_unit="angstrom", atomic_types={8}, targets=targets2)
+    info2 = DatasetInfo(length_unit="angstrom", atomic_types=[8], targets=targets2)
 
     match = r"Can't update TargetInfo with a different `unit`: \(eV != eV/Angstrom\)"
     with pytest.raises(ValueError, match=match):
@@ -292,19 +383,19 @@ def test_dataset_info_union():
     targets = TargetInfoDict()
     targets["energy"] = TargetInfo(quantity="energy", unit="eV")
     targets["forces"] = TargetInfo(quantity="mtt::forces", unit="eV/Angstrom")
-    info = DatasetInfo(length_unit="angstrom", atomic_types={1, 6}, targets=targets)
+    info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
     other_targets = targets.copy()
     other_targets["mtt::stress"] = TargetInfo(quantity="mtt::stress", unit="GPa")
 
     other_info = DatasetInfo(
-        length_unit="angstrom", atomic_types={1}, targets=other_targets
+        length_unit="angstrom", atomic_types=[1], targets=other_targets
     )
 
     union = info.union(other_info)
 
     assert union.length_unit == "angstrom"
-    assert union.atomic_types == {1, 6}
+    assert union.atomic_types == [1, 6]
     assert union.targets == other_targets
 
 
@@ -370,9 +461,9 @@ def test_get_atomic_types():
     dataset = Dataset({"system": systems, **targets})
     dataset_2 = Dataset({"system": systems_2, **targets_2})
 
-    assert get_atomic_types(dataset) == {1, 6, 7, 8}
-    assert get_atomic_types(dataset_2) == {1, 6, 8}
-    assert get_atomic_types([dataset, dataset_2]) == {1, 6, 7, 8}
+    assert get_atomic_types(dataset) == [1, 6, 7, 8]
+    assert get_atomic_types(dataset_2) == [1, 6, 8]
+    assert get_atomic_types([dataset, dataset_2]) == [1, 6, 7, 8]
 
 
 def test_get_all_targets():
@@ -545,7 +636,7 @@ def test_get_stats():
 
     dataset_info = DatasetInfo(
         length_unit="angstrom",
-        atomic_types={1, 6},
+        atomic_types=[1, 6],
         targets={
             "mtt::U0": TargetInfo(quantity="energy", unit="eV"),
             "energy": TargetInfo(quantity="energy", unit="eV"),

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -199,7 +199,7 @@ def test_read_targets(stress_dict, virial_dict, monkeypatch, tmp_path, caplog):
         assert target_info.quantity == target_section["quantity"]
         assert target_info.unit == target_section["unit"]
         assert target_info.per_atom is False
-        assert target_info.gradients == {"positions", "strain"}
+        assert target_info.gradients == ["positions", "strain"]
 
         assert type(target_list) is list
         for target in target_list:


### PR DESCRIPTION
This pull request changes the types of the `atomic_types` and `gradients` properties in the `DatasetInfo` and `TargetInfo` classes from *sets* to (unique) *lists*.

These properties were originally designed as sets because they represent collections of unique items. However, @frostedoyster  raised constant concerns about the difficulty from him working with sets in certain contexts, particularly with functions and classes that expect lists. This change aims to resolve those issues.

The `atomic_types` and `gradients` are still stored internally as sets to maintain uniqueness, but they are exposed as sorted lists for compatibility. This change has introduced additional methods and complexity to the classes which can be easily seen by number of added lines in this PR. For instance, the code had to be adjusted in various places, such as changing:

```python
new_atomic_types = merged_info.atomic_types - self.dataset_info.atomic_types
```

to a much more nested style

```python
new_atomic_types = sorted(
    set(merged_info.atomic_types) - set(self.dataset_info.atomic_types)
)
```

I must express that I am very unhappy with these changes. I think changing the types is very bad design choice. The properties `atomic_types` and `gradients` should clearly be sets due to their nature of representing unique items. Lists do not have these properties. This change, in my opinion, compromises the clarity and integrity of the code. However, I have made these changes to accommodate the concerns raised and to facilitate smoother development.

@frostedoyster, **please review** these changes to ensure that they fix your issues in #286. I expect that you (1) **add** a clear and not messy **test** in this PR to ensure that your **log files are rendered in exactly the order** you want them. (2) I encourage you to also to check and add a **test for the continuation of your SOAP BPNN model when changing types**. Scrolling through your test in `test_continue.py`, I saw no tests checking this functionality...

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--296.org.readthedocs.build/en/296/

<!-- readthedocs-preview metatrain end -->