### PR TITLE
Some infrastructure changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      action-dependencies:
+        patterns:
+          - "*" # A wildcard to create one PR for all dependencies in the ecosystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,11 @@ exclude = [
 ]
 follow_imports = 'skip'
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+# ignore" a bunch of internal warnings with Python 3.12 and PyTorch
+filterwarnings = [
+    "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning",
+    "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning",
+    "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,6 @@ lint_folders =
     "{toxinidir}/src/" \
     "{toxinidir}/tests/" \
     "{toxinidir}/docs/src/"
-warning_options = \
-    -W "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning" \
-    -W "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning" \
-    -W "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning"
-# the "-W ignore" flags above are for PyTorch, which triggers a bunch of
-# internal warnings with Python 3.12
 
 [testenv:lint]
 description = Run linters and type checks
@@ -75,7 +69,6 @@ commands =
         --cov-append \
         --cov-report= \
         --import-mode=append \
-        {[testenv]warning_options} \
         {posargs}
 
 [testenv:build]
@@ -102,7 +95,7 @@ deps =
 extras = soap-bpnn
 changedir = src/metatrain/experimental/soap_bpnn/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest {posargs}
 
 [testenv:alchemical-model-tests]
 description = Run Alchemical Model tests with pytest
@@ -112,7 +105,7 @@ deps =
 extras = alchemical-model
 changedir = src/metatrain/experimental/alchemical_model/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest {posargs}
 
 [testenv:pet-tests]
 description = Run PET tests with pytest
@@ -122,7 +115,7 @@ deps =
 extras = pet
 changedir = src/metatrain/experimental/pet/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest {posargs}
 
 [testenv:gap-tests]
 description = Run GAP tests with pytest
@@ -132,7 +125,7 @@ deps =
 extras = gap
 changedir = src/metatrain/experimental/gap/tests/
 commands =
-    pytest {[testenv]warning_options} {posargs}
+    pytest {posargs}
 
 [testenv:docs]
 description = builds the documentation with sphinx


### PR DESCRIPTION
- Add Github's dependabot for updating version's of the action. Use the same options as in metatensor.
- Move `warning_options` from `tox.ini` to `pyproject.toml`. Simplifies the tox.ini a bit.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview metatrain end -->