### PR TITLE
Fix PET training

### DIFF
--- a/src/metatrain/experimental/pet/trainer.py
+++ b/src/metatrain/experimental/pet/trainer.py
@@ -80,9 +80,6 @@ class Trainer:
 
         # set model hypers
         self.hypers["ARCHITECTURAL_HYPERS"] = model.hypers
-        dtype = train_datasets[0][0]["system"].positions.dtype
-        if dtype != torch.float32:
-            raise ValueError("PET only supports float32 as dtype")
         self.hypers["ARCHITECTURAL_HYPERS"]["DTYPE"] = "float32"
 
         # set MLIP_SETTINGS


### PR DESCRIPTION
This is a bug introduced in #294. The dtype is checked from the systems, which are now always stored in float64, and an error is raised saying that PET can only train in float32, while in reality everything is fine


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--305.org.readthedocs.build/en/305/

<!-- readthedocs-preview metatrain end -->